### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ lexilabs-basic = "+" # gets the latest version
 google-play-services-ads = "+" # you did this during the preparation step
 
 [libraries]
-lexilabs-basic-images = { module = "app.lexilabs.basic:basic-ads", version.ref = "lexilabs-basic"}
+lexilabs-basic-ads = { module = "app.lexilabs.basic:basic-ads", version.ref = "lexilabs-basic"}
 google-play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "google-play-services-ads"}
 
 [plugins] # make sure you're using the JetBrains plugin to import your composables

--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ Here's a list of the dependency versions for each release after 0.2.0:
 3. Click `File` > `Invalidate Caches...`, check all boxes and hit `invalidate and restart`
 4. Click `Sync` for gradle if banner exists. Ignore the flood of warning lights and klaxons.
 5. Click `Build` > `Clean Cache`.  Ignore the plethora of errors
-   6.Once complete, click `Build` > `Rebuild Project`. NOTE: Despite religious preference, prayer is encouraged.
+6. Once complete, click `Build` > `Rebuild Project`. NOTE: Despite religious preference, prayer is encouraged.


### PR DESCRIPTION
Use the correct alias for: `implementation(libs.lexilabs.basic.ads)`