### PR TITLE
Expose FailedToLoadAd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ google-services.json
 
 # Android Profiling
 *.hprof
+
+# Kotlin Multiplatform specific
+.kotlin/
+docs/

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -25,7 +25,7 @@ public actual class AdLoader {
     public actual fun loadInterstitialAd(
         activity: Any?,
         adUnitId: String,
-        onLoaded: () -> Unit
+        onLoaded: () -> Unit,
     ) {
         Log.d(tag, "loadInterstitialAd: Loading")
         interstitialAdUnitId = adUnitId
@@ -110,7 +110,7 @@ public actual class AdLoader {
     public actual fun loadRewardedInterstitialAd(
         activity: Any?,
         adUnitId: String,
-        onLoaded: () -> Unit
+        onLoaded: () -> Unit,
     ) {
         rewardedInterstitialAdUnitId = adUnitId
         com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
@@ -198,7 +198,7 @@ public actual class AdLoader {
     public actual fun loadRewardedAd(
         activity: Any?,
         adUnitId: String,
-        onLoaded: () -> Unit
+        onLoaded: () -> Unit,
     ) {
         rewardedAdUnitId = adUnitId
         com.google.android.gms.ads.rewarded.RewardedAd

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -26,6 +26,7 @@ public actual class AdLoader {
         activity: Any?,
         adUnitId: String,
         onLoaded: () -> Unit,
+        onFailedToLoad: (Long) -> Unit,
     ) {
         Log.d(tag, "loadInterstitialAd: Loading")
         interstitialAdUnitId = adUnitId
@@ -38,6 +39,7 @@ public actual class AdLoader {
             override fun onAdFailedToLoad(adError: com.google.android.gms.ads.LoadAdError) {
                 super.onAdFailedToLoad(adError)
                 Log.d(tag, "loadInterstitialAd:failure:$adError")
+                onFailedToLoad(adError.code.toLong())
             }
 
             override fun onAdLoaded(ad: com.google.android.gms.ads.interstitial.InterstitialAd) {
@@ -111,6 +113,7 @@ public actual class AdLoader {
         activity: Any?,
         adUnitId: String,
         onLoaded: () -> Unit,
+        onFailedToLoad: (Long) -> Unit,
     ) {
         rewardedInterstitialAdUnitId = adUnitId
         com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd
@@ -122,6 +125,7 @@ public actual class AdLoader {
                     override fun onAdFailedToLoad(adError: com.google.android.gms.ads.LoadAdError) {
                         super.onAdFailedToLoad(adError)
                         Log.d(tag, "loadRewardedInterstitialAd:failure:$adError")
+                        onFailedToLoad(adError.code.toLong())
                     }
 
                     override fun onAdLoaded(ad: com.google.android.gms.ads.rewardedinterstitial.RewardedInterstitialAd) {
@@ -199,6 +203,7 @@ public actual class AdLoader {
         activity: Any?,
         adUnitId: String,
         onLoaded: () -> Unit,
+        onFailedToLoad: (Long) -> Unit,
     ) {
         rewardedAdUnitId = adUnitId
         com.google.android.gms.ads.rewarded.RewardedAd
@@ -210,6 +215,7 @@ public actual class AdLoader {
                     override fun onAdFailedToLoad(adError: com.google.android.gms.ads.LoadAdError) {
                         super.onAdFailedToLoad(adError)
                         Log.d(tag, "loadRewardedInterstitialAd:failure:$adError")
+                        onFailedToLoad(adError.code.toLong())
                     }
 
                     override fun onAdLoaded(ad: com.google.android.gms.ads.rewarded.RewardedAd) {

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -36,7 +36,11 @@ public expect class AdLoader() {
      * @author rjamison@lexilabs.app
      * @see showInterstitialAd
      */
-    public fun loadInterstitialAd(activity: Any?, adUnitId: String, onLoaded: () -> Unit = {})
+    public fun loadInterstitialAd(
+        activity: Any?,
+        adUnitId: String,
+        onLoaded: () -> Unit = {},
+    )
 
     /**
      * Shows a fullscreen AdMob ad and notifies when the user closes the ad via [onDismissed] lambda.
@@ -70,7 +74,11 @@ public expect class AdLoader() {
      * @author rjamison@lexilabs.app
      * @see showRewardedInterstitialAd
      */
-    public fun loadRewardedInterstitialAd(activity: Any?, adUnitId: String, onLoaded: () -> Unit = {})
+    public fun loadRewardedInterstitialAd(
+        activity: Any?,
+        adUnitId: String,
+        onLoaded: () -> Unit = {},
+    )
 
     /**
      * Shows a rewarded and fullscreen AdMob ad.
@@ -108,7 +116,11 @@ public expect class AdLoader() {
      * @author rjamison@lexilabs.app
      * @see showRewardedAd
      */
-    public fun loadRewardedAd(activity: Any?, adUnitId: String, onLoaded: () -> Unit = {})
+    public fun loadRewardedAd(
+        activity: Any?,
+        adUnitId: String,
+        onLoaded: () -> Unit = {},
+    )
 
     /**
      * Shows a rewarded and fullscreen AdMob ad.

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -40,6 +40,7 @@ public expect class AdLoader() {
         activity: Any?,
         adUnitId: String,
         onLoaded: () -> Unit = {},
+        onFailedToLoad: (Long) -> Unit = {},
     )
 
     /**
@@ -78,6 +79,7 @@ public expect class AdLoader() {
         activity: Any?,
         adUnitId: String,
         onLoaded: () -> Unit = {},
+        onFailedToLoad: (Long) -> Unit = {},
     )
 
     /**
@@ -120,6 +122,7 @@ public expect class AdLoader() {
         activity: Any?,
         adUnitId: String,
         onLoaded: () -> Unit = {},
+        onFailedToLoad: (Long) -> Unit = {},
     )
 
     /**

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -38,7 +38,7 @@ public actual class AdLoader {
     public actual fun loadInterstitialAd(
         activity: Any?, /* This variable is unused, but necessary for Android */
         adUnitId: String,
-        onLoaded: () -> Unit
+        onLoaded: () -> Unit,
     ) {
         interstitialAdId = adUnitId
         GADInterstitialAd.loadWithAdUnitID(
@@ -51,7 +51,9 @@ public actual class AdLoader {
                         interstitialAd = it
                         onLoaded()
                     }
-                    p2?.let { Log.e(tag, "loadInterstitialAd:failure:$it") }
+                    p2?.let {
+                        Log.e(tag, "loadInterstitialAd:failure:$it")
+                    }
                 }
             }
         )
@@ -115,7 +117,7 @@ public actual class AdLoader {
     public actual fun loadRewardedInterstitialAd(
         activity: Any?, /* This variable is unused, but necessary for Android */
         adUnitId: String,
-        onLoaded: () -> Unit
+        onLoaded: () -> Unit,
     ) {
         rewardedInterstitialAdId = adUnitId
         GADRewardedInterstitialAd.loadWithAdUnitID(
@@ -128,7 +130,9 @@ public actual class AdLoader {
                         rewardedInterstitialAd = it
                         onLoaded()
                     }
-                    p2?.let { Log.e(tag, "loadRewardedInterstitialAd:failure:$it") }
+                    p2?.let {
+                        Log.e(tag, "loadRewardedInterstitialAd:failure:$it")
+                    }
                 }
             }
         )
@@ -201,7 +205,7 @@ public actual class AdLoader {
     public actual fun loadRewardedAd(
         activity: Any?, /* This variable is unused, but necessary for Android */
         adUnitId: String,
-        onLoaded: () -> Unit
+        onLoaded: () -> Unit,
     ) {
         rewardedAdId = adUnitId
         GADRewardedAd.loadWithAdUnitID(
@@ -214,7 +218,9 @@ public actual class AdLoader {
                         rewardedAd = it
                         onLoaded()
                     }
-                    p2?.let { Log.e(tag, "loadRewardedAd:failure:$it") }
+                    p2?.let {
+                        Log.e(tag, "loadRewardedAd:failure:$it")
+                    }
                 }
             }
         )

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -39,6 +39,7 @@ public actual class AdLoader {
         activity: Any?, /* This variable is unused, but necessary for Android */
         adUnitId: String,
         onLoaded: () -> Unit,
+        onFailedToLoad: (Long) -> Unit,
     ) {
         interstitialAdId = adUnitId
         GADInterstitialAd.loadWithAdUnitID(
@@ -53,6 +54,7 @@ public actual class AdLoader {
                     }
                     p2?.let {
                         Log.e(tag, "loadInterstitialAd:failure:$it")
+                        onFailedToLoad(it.code)
                     }
                 }
             }
@@ -118,6 +120,7 @@ public actual class AdLoader {
         activity: Any?, /* This variable is unused, but necessary for Android */
         adUnitId: String,
         onLoaded: () -> Unit,
+        onFailedToLoad: (Long) -> Unit,
     ) {
         rewardedInterstitialAdId = adUnitId
         GADRewardedInterstitialAd.loadWithAdUnitID(
@@ -132,6 +135,7 @@ public actual class AdLoader {
                     }
                     p2?.let {
                         Log.e(tag, "loadRewardedInterstitialAd:failure:$it")
+                        onFailedToLoad(it.code)
                     }
                 }
             }
@@ -206,6 +210,7 @@ public actual class AdLoader {
         activity: Any?, /* This variable is unused, but necessary for Android */
         adUnitId: String,
         onLoaded: () -> Unit,
+        onFailedToLoad: (Long) -> Unit,
     ) {
         rewardedAdId = adUnitId
         GADRewardedAd.loadWithAdUnitID(
@@ -220,6 +225,7 @@ public actual class AdLoader {
                     }
                     p2?.let {
                         Log.e(tag, "loadRewardedAd:failure:$it")
+                        onFailedToLoad(it.code)
                     }
                 }
             }


### PR DESCRIPTION
I had implemented Google Ads for Android, and decided to switch over to your library to also support iOS. The only thing missing for my flow was this `onFailedToLoad` parameter.

Use case: I use rewarded ads, where the user presses a button to see the Ad. If the ad cannot be loaded (e.g. because the Wifi is off), I show a message to the user, e.g. "The ad could not be loaded, please check your internet connection".
Similarly, it is possible the user has an ad blocker active, which also prevents the rewarded ads from working.

Example usage:

```kotlin
adLoader.loadRewardedAd(
    activity = activity,
    adUnitId = unitId,
    onLoaded = {
        println("Ad has been loaded!")
    },
    onFailedToLoad = { code ->
        println("Ad failed to load, error code: $code")
    }
)
```

Note that there is also an error message available in the `LoadAdError`/`NSError`, but I decided to not include this here since it is not very consistent between iOS (user-oriented) and Android (developer-oriented). It would also make the signature of `onFailedToLoad` a bit more complex. Thoughts about this?

Great job on the library btw!