### PR TITLE
HOTFIX - `./gradlew apiDump` is not working due to xcode 16 bug liste…

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,10 +18,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-
     steps:
-      - uses: actions/checkout@v3
-
       - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
@@ -32,9 +29,9 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build API
-        uses: ./gradlew apiDump
-
+        uses: actions/checkout@v3
       - run: |
+          ./gradlew apiDump
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .


### PR DESCRIPTION
…d in README