### PR TITLE
HOTFIX - `./gradlew apiDump` is not working due to xcode 16 bug liste…

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ jobs:
     name: HOTFIX for Xcode 16 to Dump the API
     runs-on: macos-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - name: Setup JDK 17


### PR DESCRIPTION
…d in README