### PR TITLE
Fix rewarded ad

### DIFF
--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -285,6 +285,6 @@ public actual class AdLoader {
             ) {
                 onRewardEarned()
             }
-        } ?: Log.d(tag, "The rewarded interstitial ad wasn't ready yet.")
+        } ?: Log.d(tag, "The rewarded ad wasn't ready yet.")
     }
 }

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -68,15 +68,15 @@ public actual class AdLoader {
         val viewController = UIApplication.sharedApplication.keyWindow?.rootViewController
         checkNotNull(viewController) { "Root ViewController is null" }
 
-        interstitialAd?.let {
-            interstitialAd?.fullScreenContentDelegate = FullScreenContentDelegate(
+        interstitialAd?.let { ad ->
+            ad.fullScreenContentDelegate = FullScreenContentDelegate(
                 onClick = { onClick() },
                 onImpression = { onImpression() },
                 onDismissed = { onDismissed() },
                 onFailure = { onFailure() },
                 onShown = { onShown() }
             )
-            interstitialAd?.presentFromRootViewController(viewController)
+            ad.presentFromRootViewController(viewController)
         } ?: Log.d(tag, "The interstitial ad wasn't ready yet.")
     }
 
@@ -118,15 +118,15 @@ public actual class AdLoader {
         val viewController = UIApplication.sharedApplication.keyWindow?.rootViewController
         checkNotNull(viewController) { "Root ViewController is null" }
 
-        rewardedInterstitialAd?.let {
-            rewardedInterstitialAd?.fullScreenContentDelegate = FullScreenContentDelegate(
+        rewardedInterstitialAd?.let { ad ->
+            ad.fullScreenContentDelegate = FullScreenContentDelegate(
                 onClick = onClick,
                 onDismissed = onDismissed,
                 onFailure = onFailure,
                 onImpression = onImpression,
                 onShown = onShown
             )
-            rewardedInterstitialAd?.presentFromRootViewController(
+            ad.presentFromRootViewController(
                 viewController = viewController,
                 userDidEarnRewardHandler = UserDidEarnRewardHandler(
                     onRewardEarned = { onRewardEarned() }
@@ -173,15 +173,15 @@ public actual class AdLoader {
         val viewController = UIApplication.sharedApplication.keyWindow?.rootViewController
         checkNotNull(viewController) { "Root ViewController is null" }
 
-        rewardedAd?.let {
-            rewardedAd?.fullScreenContentDelegate = FullScreenContentDelegate(
+        rewardedAd?.let { ad ->
+            ad.fullScreenContentDelegate = FullScreenContentDelegate(
                 onClick = onClick,
                 onDismissed = onDismissed,
                 onFailure = onFailure,
                 onImpression = onImpression,
                 onShown = onShown
             )
-            rewardedAd?.presentFromRootViewController(
+            ad.presentFromRootViewController(
                 rootViewController = viewController,
                 userDidEarnRewardHandler = UserDidEarnRewardHandler(
                     onRewardEarned = { onRewardEarned() }

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -132,7 +132,7 @@ public actual class AdLoader {
                     onRewardEarned = { onRewardEarned() }
                 )
             )
-        } ?: Log.d(tag, "The interstitial ad wasn't ready yet.")
+        } ?: Log.d(tag, "The rewarded interstitial ad wasn't ready yet.")
     }
 
     public actual fun loadRewardedAd(
@@ -187,7 +187,7 @@ public actual class AdLoader {
                     onRewardEarned = { onRewardEarned() }
                 )
             )
-        } ?: Log.d(tag, "The interstitial ad wasn't ready yet.")
+        } ?: Log.d(tag, "The rewarded ad wasn't ready yet.")
     }
 
 }

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdLoader.kt
@@ -174,15 +174,15 @@ public actual class AdLoader {
         checkNotNull(viewController) { "Root ViewController is null" }
 
         rewardedAd?.let {
-            rewardedInterstitialAd?.fullScreenContentDelegate = FullScreenContentDelegate(
+            rewardedAd?.fullScreenContentDelegate = FullScreenContentDelegate(
                 onClick = onClick,
                 onDismissed = onDismissed,
                 onFailure = onFailure,
                 onImpression = onImpression,
                 onShown = onShown
             )
-            rewardedInterstitialAd?.presentFromRootViewController(
-                viewController = viewController,
+            rewardedAd?.presentFromRootViewController(
+                rootViewController = viewController,
                 userDidEarnRewardHandler = UserDidEarnRewardHandler(
                     onRewardEarned = { onRewardEarned() }
                 )


### PR DESCRIPTION
Rewarded ads do not work correctly on `0.2.6-beta03` due to usage of a wrong variable (`rewardedInterstitialAd` instead of `rewardedAd`).

I also added a commit which uses a local variable instead to avoid further confusion, feel free to cherry pick the other commit if you do not like this style.

