### PR TITLE
v0.2.7

### DIFF
--- a/basic-ads/api/basic-ads.api
+++ b/basic-ads/api/basic-ads.api
@@ -17,13 +17,19 @@ public final class app/lexilabs/basic/ads/AdSize$Companion {
 	public final fun autoSelect (Lapp/lexilabs/basic/ads/AdSize;Lapp/lexilabs/basic/ads/AdSize;)Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getAUTO_HEIGHT ()I
 	public final fun getBANNER ()Lapp/lexilabs/basic/ads/AdSize;
+	public final fun getCurrentOrientationAnchoredAdaptiveBannerAdSize (Ljava/lang/Object;I)Lapp/lexilabs/basic/ads/AdSize;
+	public final fun getCurrentOrientationInlineAdaptiveBannerAdSize (Ljava/lang/Object;I)Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getFLUID ()Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getFULL_BANNER ()Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getFULL_WIDTH ()I
 	public final fun getINVALID ()Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getLARGE_BANNER ()Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getLEADERBOARD ()Lapp/lexilabs/basic/ads/AdSize;
+	public final fun getLandscapeAnchoredAdaptiveBannerAdSize (Ljava/lang/Object;I)Lapp/lexilabs/basic/ads/AdSize;
+	public final fun getLandscapeInlineAdaptiveBannerAdSize (Ljava/lang/Object;I)Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getMEDIUM_RECTANGLE ()Lapp/lexilabs/basic/ads/AdSize;
+	public final fun getPortraitAnchoredAdaptiveBannerAdSize (Ljava/lang/Object;I)Lapp/lexilabs/basic/ads/AdSize;
+	public final fun getPortraitInlineAdaptiveBannerAdSize (Ljava/lang/Object;I)Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getWIDE_SKYSCRAPER ()Lapp/lexilabs/basic/ads/AdSize;
 }
 

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
@@ -1,5 +1,7 @@
 package app.lexilabs.basic.ads
 
+import android.content.Context
+
 public actual class AdSize public actual constructor(public actual val width: Int, public actual val height: Int) {
 
     init {
@@ -19,5 +21,46 @@ public actual class AdSize public actual constructor(public actual val width: In
         public actual val INVALID: AdSize = com.google.android.gms.ads.AdSize.INVALID.toCommon()
 
         public actual fun autoSelect(androidAdSize: AdSize, iosAdSize: AdSize): AdSize = androidAdSize
+
+        public actual fun getCurrentOrientationAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize {
+            require(context != null && context is Context) {
+                "`getCurrentOrientationAnchoredAdaptiveBannerAdSize` requires argument `context` to be an Android `Context` type"
+            }
+            return com.google.android.gms.ads.AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, width).toCommon()
+        }
+
+        public actual fun getPortraitAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize {
+            require(context != null && context is Context) {
+                "`getPortraitAnchoredAdaptiveBannerAdSize` requires argument `context` to be an Android `Context` type"
+            }
+            return com.google.android.gms.ads.AdSize.getPortraitAnchoredAdaptiveBannerAdSize(context, width).toCommon()
+        }
+        public actual fun getLandscapeAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize {
+            require(context != null && context is Context) {
+                "`getLandscapeAnchoredAdaptiveBannerAdSize` requires argument `context` to be an Android `Context` type"
+            }
+            return com.google.android.gms.ads.AdSize.getLandscapeAnchoredAdaptiveBannerAdSize(context, width).toCommon()
+        }
+
+        public actual fun getCurrentOrientationInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize {
+            require(context != null && context is Context) {
+                "`getCurrentOrientationInlineAdaptiveBannerAdSize` requires argument `context` to be an Android `Context` type"
+            }
+            return com.google.android.gms.ads.AdSize.getCurrentOrientationInlineAdaptiveBannerAdSize(context, width).toCommon()
+        }
+
+        public actual fun getPortraitInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize {
+            require(context != null && context is Context) {
+                "`getPortraitInlineAdaptiveBannerAdSize` requires argument `context` to be an Android `Context` type"
+            }
+            return com.google.android.gms.ads.AdSize.getPortraitInlineAdaptiveBannerAdSize(context, width).toCommon()
+        }
+
+        public actual fun getLandscapeInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize {
+            require(context != null && context is Context) {
+                "`getLandscapeInlineAdaptiveBannerAdSize` requires argument `context` to be an Android `Context` type"
+            }
+            return com.google.android.gms.ads.AdSize.getLandscapeInlineAdaptiveBannerAdSize(context, width).toCommon()
+        }
     }
 }

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdException.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdException.kt
@@ -1,8 +1,13 @@
 package app.lexilabs.basic.ads
 
 /**
- * Indicates an issue with AdMob.
- * @param message Typically a summary of what caused the error
+ * Represents an exception that occurred during an ad operation.
+ *
+ * This exception is thrown when AdMob encounters an issue while attempting to obtain, load, or
+ * display an ad. The accompanying message provides a summary of the underlying cause of the error.
+ *
+ * @param message A descriptive message detailing the nature of the ad-related error. This message
+ *                typically summarizes the specific problem encountered during the ad operation.
  */
 public class AdException(message: String? = null): Exception(
     "AdMob failed to obtain, load, or show an ad: $message"

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
@@ -2,18 +2,18 @@ package app.lexilabs.basic.ads
 
 /**
  * Based on the AdMob implementation of AdSize, this module enables Android-like syntax to be used multiplatform.
- * @param width The width of the ad in whatever unit of measurement Google came up with
- * @param height The height of the ad in whatever unit of measurement Google came up with
- * @see FULL_WIDTH
- * @see AUTO_HEIGHT
- * @see BANNER
- * @see FULL_BANNER
- * @see LARGE_BANNER
- * @see LEADERBOARD
- * @see MEDIUM_RECTANGLE
- * @see WIDE_SKYSCRAPER
- * @see FLUID
- * @see INVALID
+ * @param width The width of the ad in density-independent pixels (dp).
+ * @param height The height of the ad in density-independent pixels (dp).
+ * @see FULL_WIDTH A dynamic ad size that matches the width of the screen.
+ * @see AUTO_HEIGHT A dynamic ad size that matches the height of the screen.
+ * @see BANNER A 320x50 banner ad.
+ * @see FULL_BANNER A 468x60 full banner ad.
+ * @see LARGE_BANNER A 320x100 large banner ad.
+ * @see LEADERBOARD A 728x90 leaderboard ad.
+ * @see MEDIUM_RECTANGLE A 300x250 medium rectangle ad.
+ * @see WIDE_SKYSCRAPER A 160x600 wide skyscraper ad.
+ * @see FLUID A dynamically sized ad that matches its parent's width and dynamically sets its height to match the ad creative.
+ * @see INVALID An invalid ad size.
  */
 @Suppress("unused")
 @DependsOnGoogleMobileAds

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
@@ -15,6 +15,7 @@ package app.lexilabs.basic.ads
  * @see FLUID
  * @see INVALID
  */
+@Suppress("unused")
 @DependsOnGoogleMobileAds
 public expect class AdSize public constructor(width: Int, height: Int) {
 
@@ -46,5 +47,53 @@ public expect class AdSize public constructor(width: Int, height: Int) {
          * @param iosAdSize The iOS implemented [AdSize]
          */
         public fun autoSelect(androidAdSize: AdSize, iosAdSize: AdSize): AdSize
+
+        /**
+         * Gets an anchored adaptive banner ad size for the current orientation.
+         * @param context Not used on iOS. Can be null.
+         * @param width The width of the ad container.
+         * @return The adaptive [AdSize].
+         */
+        public fun getCurrentOrientationAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize
+
+        /**
+         * Gets an anchored adaptive banner ad size for portrait orientation.
+         * @param context Not used on iOS. Can be null.
+         * @param width The width of the ad container.
+         * @return The adaptive [AdSize].
+         */
+        public fun getPortraitAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize
+
+        /**
+         * Gets an anchored adaptive banner ad size for landscape orientation.
+         * @param context Not used on iOS. Can be null.
+         * @param width The width of the ad container.
+         * @return The adaptive [AdSize].
+         */
+        public fun getLandscapeAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize
+
+        /**
+         * Gets an inline adaptive banner ad size for the current orientation.
+         * @param context Not used on iOS. Can be null.
+         * @param width The width of the ad container.
+         * @return The adaptive [AdSize].
+         */
+        public fun getCurrentOrientationInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize
+
+        /**
+         * Gets an inline adaptive banner ad size for portrait orientation.
+         * @param context Not used on iOS. Can be null.
+         * @param width The width of the ad container.
+         * @return The adaptive [AdSize].
+         */
+        public fun getPortraitInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize
+
+        /**
+         * Gets an inline adaptive banner ad size for landscape orientation.
+         * @param context Not used on iOS. Can be null.
+         * @param width The width of the ad container.
+         * @return The adaptive [AdSize].
+         */
+        public fun getLandscapeInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize
     }
 }

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdUnitId.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdUnitId.kt
@@ -1,9 +1,19 @@
 package app.lexilabs.basic.ads
 
 /**
- * An object used to hold functions related to AdMob AdUnitIds
- * @see AdUnitId.autoSelect
+ * An object used to hold functions related to AdMob AdUnitIds.
+ *
+ * This object provides a way to manage and access AdMob AdUnitIds for different ad types and platforms.
+ * It includes a utility function for selecting the appropriate AdUnitId based on the current platform (Android or iOS)
+ * and provides default AdUnitIds for common ad formats.
+ *
+ * @see AdUnitId.autoSelect For selecting AdUnitIds dynamically based on the platform.
+ * @see BANNER_DEFAULT Default AdUnitId for Banner ads.
+ * @see INTERSTITIAL_DEFAULT Default AdUnitId for Interstitial ads.
+ * @see REWARDED_INTERSTITIAL_DEFAULT Default AdUnitId for Rewarded Interstitial ads.
+ * @see REWARDED_DEFAULT Default AdUnitId for Rewarded ads.
  */
+@Suppress("unused")
 public expect object AdUnitId {
     /**
      * Provides a way of selecting an AdMob AdUnitId by platform during runtime.

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/BannerAdHandler.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/BannerAdHandler.kt
@@ -1,30 +1,60 @@
 package app.lexilabs.basic.ads
 
-import app.lexilabs.basic.ads.composable.rememberBannerAd
-
 /**
  * A [BannerAdHandler] creates landscape ads that cover part of the host app screen.
  *
- * @param activity Android required Activity
+ * This class is responsible for loading and managing the state of a banner advertisement
+ * provided by Google Mobile Ads. It requires an Android `Activity` for its operations.
+ *
+ * **Usage Example:**
  *
  * ```kotlin
- * // Instantiate
- * val ad = BannerAdHandler(activity)
- * // Load the Ad
- * ad.load(
- *   adUnitId = "AD_UNIT_ID_GOES_HERE", // Banner Ad Unit ID from AdMob
- *   adSize = AdSize.FULL_BANNER // Banner AdSize goes here
- *   onFailure = {}, // Callback when ad fails to display
- *   onDismissed = {}, // Callback when ad is dismissed
- *   onShown = {}, // Callback after ad is shown
- *   onImpression = {}, // Callback after the ad makes an impression
- *   onClick = {} // Callback on ad click
- * )
- * // Show the ad in your Composable
- * BannerAd(ad)
+ * // In your Composable function or where you have access to an Activity:
+ * val activity = LocalContext.current as Activity
+ *
+ * // Instantiate the BannerAdHandler
+ * val adHandler = rememberBannerAd(activity = activity)
+ *
+ * // Load the Ad (typically in a LaunchedEffect or similar)
+ * LaunchedEffect(Unit) {
+ *   adHandler.load(
+ *     adUnitId = "YOUR_ADMOB_BANNER_AD_UNIT_ID", // Replace with your actual Ad Unit ID
+ *     adSize = AdSize.BANNER, // Or any other desired AdSize
+ *     onLoad = {
+ *       // Ad loaded successfully
+ *       println("Banner Ad loaded!")
+ *     },
+ *     onFailure = { exception ->
+ *       // Ad failed to load
+ *       println("Banner Ad failed to load: ${exception.message}")
+ *     },
+ *     onDismissed = {
+ *       // Ad was dismissed (not typical for banners, but callback exists)
+ *       println("Banner Ad dismissed.")
+ *     },
+ *     onShown = {
+ *       // Ad is now visible on screen
+ *       println("Banner Ad shown.")
+ *     },
+ *     onImpression = {
+ *       // Ad impression has been recorded
+ *       println("Banner Ad impression recorded.")
+ *     },
+ *     onClick = {
+ *       // User clicked on the ad
+ *       println("Banner Ad clicked.")
+ *     }
+ *   )
+ * }
+ *
+ * // Display the ad in your Composable UI
+ * if (adHandler.state == AdState.Loaded) { // Or handle other states like Loading, Error
+ *   BannerAd(adHandler)
+ * }
  * ```
- * @see rememberBannerAd
- * @see load
+ *
+ * @param activity The Android `Activity` required for displaying the ad.
+ *                 On platforms other than Android, this parameter might be unused or expect a platform-specific equivalent.
  */
 @DependsOnGoogleMobileAds
 public expect class BannerAdHandler(activity: Any?) {

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/Consent.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/Consent.kt
@@ -10,6 +10,7 @@ package app.lexilabs.basic.ads
  * The [Consent] class [require]s the Activity be a non-null Context on Android
  * @param activity [require]s non-null Activity Context on Android. All other platforms can pass `null`
  */
+@ExperimentalBasicAds
 @DependsOnGoogleUserMessagingPlatform
 public expect class Consent(activity: Any?) {
 

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/ConsentDebugSettings.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/ConsentDebugSettings.kt
@@ -71,13 +71,15 @@ public expect class ConsentDebugSettings {
     }
 
     /**
-     * Location of [DebugGeography] to test the [Consent.requestConsentInfoUpdate]
+     * Enum class representing different debug geography settings for testing consent flows.
+     * These settings allow developers to simulate user locations to test how the
+     * [Consent.requestConsentInfoUpdate] behaves under different geographical regulations.
      *
-     * @see DEBUG_GEOGRAPHY_DISABLED
-     * @see DEBUG_GEOGRAPHY_EEA
-     * @see DEBUG_GEOGRAPHY_NOT_EEA
-     * @see DEBUG_GEOGRAPHY_REGULATED_US_STATE
-     * @see DEBUG_GEOGRAPHY_OTHER
+     * @see DEBUG_GEOGRAPHY_DISABLED Disables debug geography settings. The consent SDK will behave as if the device is not in a debug geography.
+     * @see DEBUG_GEOGRAPHY_EEA Simulates the device being located within the European Economic Area (EEA).
+     * @see DEBUG_GEOGRAPHY_NOT_EEA Simulates the device being located outside the European Economic Area (EEA).
+     * @see DEBUG_GEOGRAPHY_REGULATED_US_STATE Simulates the device being located in a US state with specific privacy regulations (e.g., California).
+     * @see DEBUG_GEOGRAPHY_OTHER Simulates the device being located in a region not covered by the other specific debug geographies.
      */
     public enum class DebugGeography {
         DEBUG_GEOGRAPHY_DISABLED,

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/ConsentException.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/ConsentException.kt
@@ -1,8 +1,15 @@
 package app.lexilabs.basic.ads
 
 /**
- * Indicates an issue with UMP module for consent.
- * @param message Typically a summary of what caused the error
+ * Indicates an issue with the User Messaging Platform (UMP) module, which is responsible for
+ * obtaining, loading, or showing consent information from the user.
+ *
+ * This exception is typically thrown when the UMP encounters an error during its operation,
+ * such as failing to connect to the server, experiencing a network issue, or encountering
+ * an unexpected internal error.
+ *
+ * @param message A descriptive message summarizing the cause of the error. This message
+ *                provides additional context to help diagnose and resolve the issue.
  */
 @DependsOnGoogleUserMessagingPlatform
 public class ConsentException(message: String?): Exception(

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/ConsentRequestParameters.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/ConsentRequestParameters.kt
@@ -1,7 +1,9 @@
 package app.lexilabs.basic.ads
 
 /**
- * Parameters sent on updating user consent info.
+ * Parameters sent when updating user consent information.
+ *
+ * This class encapsulates parameters used when requesting an update to the user's consent status.
  *
  * @see getConsentDebugSettings
  * @see getIsTagForUnderAgeOfConsent

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/DependsOnGoogleUserMessagingPlatform.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/DependsOnGoogleUserMessagingPlatform.kt
@@ -1,11 +1,17 @@
 package app.lexilabs.basic.ads
 
 /**
- * For **Android**, complete [these steps in Google's UMP instructions](https://developers.google.com/admob/android/privacy).
+ * Annotation for APIs that depend on the Google User Messaging Platform (UMP) library.
  *
- * For **iOS**, complete [these steps in Google's UMP instructions](https://developers.google.com/admob/ios/privacy).
+ * The UMP library is used to request consent from users in the European Economic Area (EEA), the UK, and Switzerland.
+ *
+ * For more information on how to integrate the UMP library, please see the following documentation:
+ *
+ * - **Android**: [Google's UMP instructions for Android](https://developers.google.com/admob/android/privacy)
+ * - **iOS**: [Google's UMP instructions for iOS](https://developers.google.com/admob/ios/privacy)
  */
+@Suppress("ExperimentalAnnotationRetention")
 @RequiresOptIn(message = "Depends on Google User Messaging Platform library for Android and iOS")
-@Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
+@Retention(AnnotationRetention.BINARY)
 public annotation class DependsOnGoogleUserMessagingPlatform

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/ExperimentalBasicAds.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/ExperimentalBasicAds.kt
@@ -1,7 +1,12 @@
 package app.lexilabs.basic.ads
 
 /**
- * This API is not considered 'production' until reaching version 1.0.0 or higher
+ * Marks declarations that are still **experimental** in the Basic Ads API.
+ *
+ * Such declarations may be changed in backward-incompatible ways or even removed in the future.
+ * Do not use them in production code.
+ *
+ * This API is not considered 'production' until reaching version 1.0.0 or higher.
  */
 @RequiresOptIn(message = "This API is experimental, unstable, and will definitely change.")
 @Retention(AnnotationRetention.BINARY)

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/RequestConfiguration.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/RequestConfiguration.kt
@@ -19,6 +19,12 @@ public data class RequestConfiguration(
     val tagForUnderAgeOfConsent: Int,
     val testDeviceIds: List<String?>?
 ){
+    /**
+     * Enum for the state of publisher privacy personalization.
+     * @property DEFAULT The default state, which may be determined by other settings.
+     * @property ENABLED Publisher has opted to enable personalized advertising.
+     * @property DISABLED Publisher has opted to disable personalized advertising.
+     */
     public enum class PublisherPrivacyPersonalizationState(private val value: Int) {
         DEFAULT(0),
         ENABLED(1),

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/ConsentPopup.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/ConsentPopup.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import app.lexilabs.basic.ads.Consent
 import app.lexilabs.basic.ads.DependsOnGoogleUserMessagingPlatform
+import app.lexilabs.basic.ads.ExperimentalBasicAds
 
 /**
  * A composable function that requests and updates user consent information using the Google User Messaging Platform (UMP) SDK.
@@ -23,6 +24,7 @@ import app.lexilabs.basic.ads.DependsOnGoogleUserMessagingPlatform
  * @see rememberConsent
  * @see DependsOnGoogleUserMessagingPlatform
  */
+@ExperimentalBasicAds
 @DependsOnGoogleUserMessagingPlatform
 @Composable
 public fun ConsentPopup(
@@ -50,6 +52,7 @@ public fun ConsentPopup(
  * details about the error. By default, this parameter is an empty lambda function, which means
  * that errors are ignored.
  */
+@ExperimentalBasicAds
 @DependsOnGoogleUserMessagingPlatform
 @Composable
 public fun ConsentPopup(

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/ConsentPopup.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/ConsentPopup.kt
@@ -5,6 +5,24 @@ import androidx.compose.runtime.getValue
 import app.lexilabs.basic.ads.Consent
 import app.lexilabs.basic.ads.DependsOnGoogleUserMessagingPlatform
 
+/**
+ * A composable function that requests and updates user consent information using the Google User Messaging Platform (UMP) SDK.
+ * It is designed to be used within a Composable UI context.
+ *
+ * This function handles the process of checking the current consent status and requesting an update if necessary.
+ * If a consent form is required and available, it will be presented to the user.
+ *
+ * This function relies on the [Consent] class to manage the underlying UMP SDK interactions.
+ *
+ * @param activity The current Android Activity. This is required by the UMP SDK to display the consent form.
+ *                 It's typed as `Any?` to allow for flexibility, but it should be an instance of `android.app.Activity`.
+ * @param onFailure A lambda function that will be invoked if an error occurs during the consent information update process.
+ *                  It receives an [Exception] object describing the error. Defaults to an empty lambda.
+ *
+ * @see Consent
+ * @see rememberConsent
+ * @see DependsOnGoogleUserMessagingPlatform
+ */
 @DependsOnGoogleUserMessagingPlatform
 @Composable
 public fun ConsentPopup(
@@ -15,6 +33,23 @@ public fun ConsentPopup(
     consent.requestConsentInfoUpdate(onError = onFailure)
 }
 
+/**
+ * A Composable function that requests an update to the consent information.
+ *
+ * This function is used to ensure that the app has the latest consent status from the user.
+ * It is typically called when the app starts or when the user's consent status might have changed.
+ *
+ * This function is annotated with `@DependsOnGoogleUserMessagingPlatform` because it relies on the
+ * Google User Messaging Platform (UMP) SDK to manage user consent. The UMP SDK provides a
+ * standardized way to obtain and manage user consent for personalized advertising.
+ *
+ * @param consent The [Consent] object that manages the consent state. This object is typically
+ * obtained using the `rememberConsent` function.
+ * @param onFailure A lambda function that is called if an error occurs while updating the consent
+ * information. The lambda function takes an [Exception] object as a parameter, which provides
+ * details about the error. By default, this parameter is an empty lambda function, which means
+ * that errors are ignored.
+ */
 @DependsOnGoogleUserMessagingPlatform
 @Composable
 public fun ConsentPopup(

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberBannerAd.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberBannerAd.kt
@@ -10,6 +10,30 @@ import app.lexilabs.basic.ads.AdUnitId
 import app.lexilabs.basic.ads.BannerAdHandler
 import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
 
+/**
+ * A Composable function that remembers a [BannerAdHandler] across compositions.
+ *
+ * This function creates and manages a [BannerAdHandler] instance, ensuring it persists
+ * across recompositions. It automatically attempts to load an ad when the ad's state
+ * is [AdState.DISMISSED] or [AdState.NONE].
+ *
+ * **Note:** This Composable depends on the Google Mobile Ads SDK. Ensure that the
+ * SDK is properly integrated into your project.
+ *
+ * @param activity The current Activity or Context. This is crucial for the ad to function correctly.
+ *                 It's recommended to pass the result of `LocalContext.current as Activity`.
+ * @param adUnitId The ad unit ID for the banner ad. Defaults to [AdUnitId.BANNER_DEFAULT].
+ * @param adSize The size of the banner ad. Defaults to [AdSize.FULL_BANNER].
+ * @param onLoad A callback invoked when the ad has successfully loaded.
+ * @param onFailure A callback invoked when the ad fails to load. It provides an [Exception]
+ *                  with details about the failure.
+ * @param onDismissed A callback invoked when the ad is dismissed by the user.
+ * @param onShown A callback invoked when the ad is shown on the screen.
+ * @param onImpression A callback invoked when an impression is recorded for the ad.
+ * @param onClick A callback invoked when the ad is clicked by the user.
+ * @return A [MutableState] holding the [BannerAdHandler]. You can use this state to
+ *         interact with the ad (e.g., to display it in your UI).
+ */
 @DependsOnGoogleMobileAds
 @Composable
 public fun rememberBannerAd(

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberConsent.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberConsent.kt
@@ -7,6 +7,23 @@ import androidx.compose.runtime.remember
 import app.lexilabs.basic.ads.Consent
 import app.lexilabs.basic.ads.DependsOnGoogleUserMessagingPlatform
 
+/**
+ * Composable function to remember and manage user consent for ads.
+ *
+ * This function creates and remembers a [Consent] object, which handles interactions
+ * with the Google User Messaging Platform (UMP) SDK to obtain and manage user consent
+ * for personalized advertising.
+ *
+ * It initializes the consent state and checks if privacy options are required and if ads can be requested.
+ *
+ * @param activity The current Activity context. This is crucial for the UMP SDK to function correctly.
+ *                 It's recommended to pass the result of `LocalContext.current as? Activity`.
+ * @return A [MutableState] holding the [Consent] object. This allows observing and reacting
+ *         to changes in the consent status within your Composable UI.
+ *
+ * @see Consent
+ * @see DependsOnGoogleUserMessagingPlatform
+ */
 @DependsOnGoogleUserMessagingPlatform
 @Composable
 public fun rememberConsent(activity: Any?): MutableState<Consent> {

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberConsent.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberConsent.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import app.lexilabs.basic.ads.Consent
 import app.lexilabs.basic.ads.DependsOnGoogleUserMessagingPlatform
+import app.lexilabs.basic.ads.ExperimentalBasicAds
 
 /**
  * Composable function to remember and manage user consent for ads.
@@ -24,6 +25,7 @@ import app.lexilabs.basic.ads.DependsOnGoogleUserMessagingPlatform
  * @see Consent
  * @see DependsOnGoogleUserMessagingPlatform
  */
+@ExperimentalBasicAds
 @DependsOnGoogleUserMessagingPlatform
 @Composable
 public fun rememberConsent(activity: Any?): MutableState<Consent> {

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberInterstitialAd.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberInterstitialAd.kt
@@ -9,6 +9,18 @@ import app.lexilabs.basic.ads.AdUnitId
 import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
 import app.lexilabs.basic.ads.InterstitialAdHandler
 
+/**
+ * Composable function to remember an interstitial ad.
+ *
+ * This function creates and manages an [InterstitialAdHandler] instance,
+ * automatically loading an ad when the state is [AdState.DISMISSED] or [AdState.NONE].
+ *
+ * @param activity The activity context, required for ad loading.
+ * @param adUnitId The ad unit ID for the interstitial ad. Defaults to [AdUnitId.INTERSTITIAL_DEFAULT].
+ * @param onLoad A callback function invoked when the ad is successfully loaded.
+ * @param onFailure A callback function invoked when ad loading fails, providing the [Exception] that occurred.
+ * @return A [MutableState] holding the [InterstitialAdHandler]. You can use this to control and observe the ad's state (e.g., to show the ad).
+ */
 @DependsOnGoogleMobileAds
 @Composable
 public fun rememberInterstitialAd(

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberRewardedAd.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberRewardedAd.kt
@@ -9,6 +9,18 @@ import app.lexilabs.basic.ads.AdUnitId
 import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
 import app.lexilabs.basic.ads.RewardedAdHandler
 
+/**
+ * Remembers a [RewardedAdHandler], which is used to load and show rewarded ads.
+ *
+ * This function will automatically attempt to load an ad when the [RewardedAdHandler.state]
+ * is [AdState.NONE] or [AdState.DISMISSED].
+ *
+ * @param activity The activity to use for loading and showing the ad. This should be an Android `Activity`.
+ * @param adUnitId The ad unit ID to use for loading the ad. Defaults to [AdUnitId.REWARDED_DEFAULT].
+ * @param onLoad A callback that will be invoked when the ad has successfully loaded.
+ * @param onFailure A callback that will be invoked if the ad fails to load, providing an [Exception] with details of the failure.
+ * @return A [MutableState] holding the [RewardedAdHandler]. You can observe this state to react to changes in the ad's lifecycle.
+ */
 @DependsOnGoogleMobileAds
 @Composable
 public fun rememberRewardedAd(

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberRewardedInterstitialAd.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberRewardedInterstitialAd.kt
@@ -9,6 +9,25 @@ import app.lexilabs.basic.ads.AdUnitId
 import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
 import app.lexilabs.basic.ads.RewardedInterstitialAdHandler
 
+/**
+ * A composable function that remembers and manages a RewardedInterstitialAdHandler.
+ *
+ * This function handles the lifecycle of a rewarded interstitial ad, including loading and reloading it
+ * when it's dismissed or hasn't been loaded yet.
+ *
+ * @param activity The current activity context. This is crucial for initializing and displaying the ad.
+ *                 It can be null, but ads will not function correctly if it is.
+ * @param adUnitId The ad unit ID for the rewarded interstitial ad. Defaults to [AdUnitId.REWARDED_INTERSTITIAL_DEFAULT].
+ * @param onLoad A callback function that is invoked when the ad has successfully loaded.
+ * @param onFailure A callback function that is invoked if the ad fails to load.
+ *                  It provides an [Exception] object containing details about the failure.
+ * @return A [MutableState] holding the [RewardedInterstitialAdHandler]. This allows you to interact
+ *         with the ad (e.g., to show it) and observe its state.
+ *
+ * @see RewardedInterstitialAdHandler
+ * @see AdUnitId.REWARDED_INTERSTITIAL_DEFAULT
+ * @see DependsOnGoogleMobileAds
+ */
 @DependsOnGoogleMobileAds
 @Composable
 public fun rememberRewardedInterstitialAd(

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
@@ -10,6 +10,11 @@ import cocoapods.Google_Mobile_Ads_SDK.GADAdSizeLeaderboard
 import cocoapods.Google_Mobile_Ads_SDK.GADAdSizeMediumRectangle
 import cocoapods.Google_Mobile_Ads_SDK.GADAdSizeSkyscraper
 import cocoapods.Google_Mobile_Ads_SDK.GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth
+import cocoapods.Google_Mobile_Ads_SDK.GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth
+import cocoapods.Google_Mobile_Ads_SDK.GADLandscapeAnchoredAdaptiveBannerAdSizeWithWidth
+import cocoapods.Google_Mobile_Ads_SDK.GADLandscapeInlineAdaptiveBannerAdSizeWithWidth
+import cocoapods.Google_Mobile_Ads_SDK.GADPortraitAnchoredAdaptiveBannerAdSizeWithWidth
+import cocoapods.Google_Mobile_Ads_SDK.GADPortraitInlineAdaptiveBannerAdSizeWithWidth
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
@@ -33,6 +38,24 @@ public actual class AdSize actual constructor(public actual val width: Int, publ
         public actual val INVALID: AdSize get() = GADAdSizeInvalid.toCommon()
 
         public actual fun autoSelect(androidAdSize: AdSize, iosAdSize: AdSize): AdSize = iosAdSize
+
+        public actual fun getCurrentOrientationAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize =
+            GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(width.toDouble()).toAdSize()
+
+        public actual fun getPortraitAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize =
+            GADPortraitAnchoredAdaptiveBannerAdSizeWithWidth(width.toDouble()).toAdSize()
+
+        public actual fun getLandscapeAnchoredAdaptiveBannerAdSize(context: Any?, width: Int): AdSize =
+            GADLandscapeAnchoredAdaptiveBannerAdSizeWithWidth(width.toDouble()).toAdSize()
+
+        public actual fun getCurrentOrientationInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize =
+            GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth(width.toDouble()).toAdSize()
+
+        public actual fun getPortraitInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize =
+            GADPortraitInlineAdaptiveBannerAdSizeWithWidth(width.toDouble()).toAdSize()
+
+        public actual fun getLandscapeInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize =
+            GADLandscapeInlineAdaptiveBannerAdSizeWithWidth(width.toDouble()).toAdSize()
     }
     public fun toIos(): GADAdSize {
         return when(this) {

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/Consent.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/Consent.kt
@@ -20,6 +20,7 @@ import platform.Foundation.NSError
  * @param activity [require] non-null Activity Context on Android. All other platforms can pass `null`
  */
 @OptIn(ExperimentalForeignApi::class)
+@ExperimentalBasicAds
 @DependsOnGoogleUserMessagingPlatform
 public actual class Consent actual constructor(activity: Any?) {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # BUILD INFO
-ads = "0.2.7-beta04"
+ads = "0.2.7"
 build-sdk-compile = "36"
 build-sdk-min = "24"
 build-sdk-target = "36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ annotations = "1.9.1"
 kover = "0.9.1"
 logging = "0.2.6"
 android-ump = "3.2.0"
-maven-publish = "0.33.0"
+maven-publish = "0.34.0"
 
 [libraries]
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }


### PR DESCRIPTION
Improve KDoc documentation for public APIs

Enhanced the KDoc comments for several public classes, functions, and enums within the `basic-ads` module. This includes:

- `AdException.kt`: Clarified the purpose and context of the exception.
- `AdSize.kt`: Provided more descriptive explanations for each ad size constant and parameters.
- `AdUnitId.kt`: Added a more comprehensive overview of the object's purpose and its members.
- `BannerAdHandler.kt`: Added a detailed usage example and improved parameter descriptions.
- `ConsentDebugSettings.kt`: Improved the KDoc for the `DebugGeography` enum and its values.
- `ConsentException.kt`: Provided more context on when this exception might be thrown.
- `ConsentRequestParameters.kt`: Clarified the purpose of the class.
- `DependsOnGoogleUserMessagingPlatform.kt`: Updated the description and links to Google's documentation.
- `ExperimentalBasicAds.kt`: Refined the explanation of the experimental API status.
- `RequestConfiguration.kt`: Added KDoc for the `PublisherPrivacyPersonalizationState` enum.
- `composable/ConsentPopup.kt`: Added detailed KDoc for both overloaded functions, explaining their purpose and parameters.
- `composable/RememberBannerAd.kt`: Added comprehensive KDoc including a note about SDK dependency and parameter explanations.
- `composable/RememberConsent.kt`: Added detailed KDoc explaining the function's role and parameters.
- `composable/RememberInterstitialAd.kt`: Added detailed KDoc explaining the function's purpose and parameters.
- `composable/RememberRewardedAd.kt`: Added detailed KDoc explaining the function's role and parameters.
- `composable/RememberRewardedInterstitialAd.kt`: Added comprehensive KDoc detailing the function's behavior and parameters.