### PR TITLE
Version 1.0.0-beta02

### DIFF
--- a/basic-ads/api/basic-ads.api
+++ b/basic-ads/api/basic-ads.api
@@ -23,6 +23,7 @@ public final class app/lexilabs/basic/ads/AdSize$Companion {
 	public final fun getFULL_BANNER ()Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getFULL_WIDTH ()I
 	public final fun getINVALID ()Lapp/lexilabs/basic/ads/AdSize;
+	public final fun getInlineAdaptiveBannerAdSize (II)Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getLARGE_BANNER ()Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getLEADERBOARD ()Lapp/lexilabs/basic/ads/AdSize;
 	public final fun getLandscapeAnchoredAdaptiveBannerAdSize (Ljava/lang/Object;I)Lapp/lexilabs/basic/ads/AdSize;

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
@@ -62,5 +62,8 @@ public actual class AdSize public actual constructor(public actual val width: In
             }
             return com.google.android.gms.ads.AdSize.getLandscapeInlineAdaptiveBannerAdSize(context, width).toCommon()
         }
+
+        public actual fun getInlineAdaptiveBannerAdSize(width: Int, maxHeight: Int): AdSize =
+            com.google.android.gms.ads.AdSize.getInlineAdaptiveBannerAdSize(width, maxHeight).toCommon()
     }
 }

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
@@ -95,5 +95,13 @@ public expect class AdSize public constructor(width: Int, height: Int) {
          * @return The adaptive [AdSize].
          */
         public fun getLandscapeInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize
+
+        /**
+         * Gets an inline adaptive banner ad size for any orientation.
+         * @param width The width of the ad container.
+         * @param maxHeight The maximum height of the ad container.
+         * @return The adaptive [AdSize].
+         */
+        public fun getInlineAdaptiveBannerAdSize(width: Int, maxHeight: Int): AdSize
     }
 }

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdSize.kt
@@ -11,6 +11,7 @@ import cocoapods.Google_Mobile_Ads_SDK.GADAdSizeMediumRectangle
 import cocoapods.Google_Mobile_Ads_SDK.GADAdSizeSkyscraper
 import cocoapods.Google_Mobile_Ads_SDK.GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth
 import cocoapods.Google_Mobile_Ads_SDK.GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth
+import cocoapods.Google_Mobile_Ads_SDK.GADInlineAdaptiveBannerAdSizeWithWidthAndMaxHeight
 import cocoapods.Google_Mobile_Ads_SDK.GADLandscapeAnchoredAdaptiveBannerAdSizeWithWidth
 import cocoapods.Google_Mobile_Ads_SDK.GADLandscapeInlineAdaptiveBannerAdSizeWithWidth
 import cocoapods.Google_Mobile_Ads_SDK.GADPortraitAnchoredAdaptiveBannerAdSizeWithWidth
@@ -56,6 +57,9 @@ public actual class AdSize actual constructor(public actual val width: Int, publ
 
         public actual fun getLandscapeInlineAdaptiveBannerAdSize(context: Any?, width: Int): AdSize =
             GADLandscapeInlineAdaptiveBannerAdSizeWithWidth(width.toDouble()).toAdSize()
+
+        public actual fun getInlineAdaptiveBannerAdSize(width: Int, maxHeight: Int): AdSize =
+            GADInlineAdaptiveBannerAdSizeWithWidthAndMaxHeight(width.toDouble(), maxHeight.toDouble()).toAdSize()
     }
     public fun toIos(): GADAdSize {
         return when(this) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 # BUILD INFO
-ads = "1.0.0-beta01"
+ads = "1.0.0-beta02"
 build-sdk-compile = "36"
 build-sdk-min = "24"
 build-sdk-target = "36"
 build-ios-target-deployment = "13.0"
 kotlin = "2.2.0"
-agp = "8.11.1"
+agp = "8.12.0"
 # COCOAPODS DEPENDENCIES
 cocoapods-admob = "12.4.0"
 cocoapods-ump = "3.0.0"
@@ -14,7 +14,7 @@ cocoapods-ump = "3.0.0"
 bcv = "0.18.1"
 dokka = "2.0.0"
 compose = "1.8.2"
-google-play-services-ads = "24.4.0"
+google-play-services-ads = "24.5.0"
 annotations = "1.9.1"
 kover = "0.9.1"
 logging = "0.2.6"


### PR DESCRIPTION
This commit introduces the `getInlineAdaptiveBannerAdSize` function for fetching inline adaptive banner ad sizes irrespective of device orientation. It also includes updates to library versions.

*   **New Functionality:**
    *   Added `AdSize.getInlineAdaptiveBannerAdSize(width, maxHeight)` to the common, Android, and iOS implementations. This function allows developers to get an inline adaptive ad size by specifying the width and maximum height.
        *   On Android, it wraps `com.google.android.gms.ads.AdSize.getInlineAdaptiveBannerAdSize(width, maxHeight)`.
        *   On iOS, it wraps `GADInlineAdaptiveBannerAdSizeWithWidthAndMaxHeight(width, maxHeight)`.

*   **Dependency Updates:**
    *   The ads library version is updated from `1.0.0-beta01` to `1.0.0-beta02`.
    *   Android Gradle Plugin (AGP) version updated from `8.11.1` to `8.12.0`.
    *   Google Play Services Ads library updated from `24.4.0` to `24.5.0`.
    These changes are reflected in the `gradle/libs.versions.toml` file.

*   **API Update:**
    *   The `basic-ads.api` file has been updated to include the new `getInlineAdaptiveBannerAdSize` function.