### PR TITLE
v1.0.0-beta04 (#98)

### DIFF
--- a/basic-ads/api/basic-ads.api
+++ b/basic-ads/api/basic-ads.api
@@ -52,6 +52,7 @@ public final class app/lexilabs/basic/ads/AdUnitId {
 	public static final field BANNER_DEFAULT Ljava/lang/String;
 	public static final field INSTANCE Lapp/lexilabs/basic/ads/AdUnitId;
 	public static final field INTERSTITIAL_DEFAULT Ljava/lang/String;
+	public static final field NATIVE_DEFAULT Ljava/lang/String;
 	public static final field REWARDED_DEFAULT Ljava/lang/String;
 	public static final field REWARDED_INTERSTITIAL_DEFAULT Ljava/lang/String;
 	public final fun autoSelect (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
@@ -292,6 +293,15 @@ public final class app/lexilabs/basic/ads/composable/InterstitialAdKt {
 	public static final fun InterstitialAd (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class app/lexilabs/basic/ads/composable/NativeAdDefaultKt {
+	public static final fun NativeAdDefault (Ljava/lang/Object;Lapp/lexilabs/basic/ads/nativead/NativeAdData;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class app/lexilabs/basic/ads/composable/NativeAdKt {
+	public static final fun NativeAd (Lapp/lexilabs/basic/ads/nativead/NativeAdHandler;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public static final fun NativeAd (Ljava/lang/Object;Lkotlin/jvm/functions/Function3;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+}
+
 public final class app/lexilabs/basic/ads/composable/RememberBannerAdKt {
 	public static final fun rememberBannerAd (Ljava/lang/Object;Ljava/lang/String;Lapp/lexilabs/basic/ads/AdSize;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Landroidx/compose/runtime/MutableState;
 }
@@ -302,6 +312,10 @@ public final class app/lexilabs/basic/ads/composable/RememberConsentKt {
 
 public final class app/lexilabs/basic/ads/composable/RememberInterstitialAdKt {
 	public static final fun rememberInterstitialAd (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/runtime/MutableState;
+}
+
+public final class app/lexilabs/basic/ads/composable/RememberNativeAdKt {
+	public static final fun rememberNativeAd (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Landroidx/compose/runtime/MutableState;
 }
 
 public final class app/lexilabs/basic/ads/composable/RememberRewardedAdKt {
@@ -320,5 +334,73 @@ public final class app/lexilabs/basic/ads/composable/RewardedAdKt {
 public final class app/lexilabs/basic/ads/composable/RewardedInterstitialAdKt {
 	public static final fun RewardedInterstitialAd (Lapp/lexilabs/basic/ads/RewardedInterstitialAdHandler;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun RewardedInterstitialAd (Ljava/lang/Object;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class app/lexilabs/basic/ads/nativead/NativeAdConvertersKt {
+	public static final fun toCommon (Lcom/google/android/gms/ads/MediaContent;)Lapp/lexilabs/basic/ads/nativead/NativeAdData$MediaContent;
+	public static final fun toCommon (Lcom/google/android/gms/ads/MuteThisAdReason;)Lapp/lexilabs/basic/ads/nativead/NativeAdData$MuteThisAdReason;
+	public static final fun toCommon (Lcom/google/android/gms/ads/nativead/NativeAd$AdChoicesInfo;)Lapp/lexilabs/basic/ads/nativead/NativeAdData$AdChoicesInfo;
+	public static final fun toCommon (Lcom/google/android/gms/ads/nativead/NativeAd$Image;)Lapp/lexilabs/basic/ads/nativead/NativeAdData$Image;
+	public static final fun toCommon (Lcom/google/android/gms/ads/nativead/NativeAd;)Lapp/lexilabs/basic/ads/nativead/NativeAdData;
+}
+
+public final class app/lexilabs/basic/ads/nativead/NativeAdData {
+	public static final field $stable I
+	public fun <init> (Lapp/lexilabs/basic/ads/nativead/NativeAdData$AdChoicesInfo;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lapp/lexilabs/basic/ads/nativead/NativeAdData$Image;Lapp/lexilabs/basic/ads/nativead/NativeAdData$MediaContent;Ljava/util/List;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Double;Ljava/lang/String;)V
+	public final fun getAdChoicesInfo ()Lapp/lexilabs/basic/ads/nativead/NativeAdData$AdChoicesInfo;
+	public final fun getAdvertiser ()Ljava/lang/String;
+	public final fun getBody ()Ljava/lang/String;
+	public final fun getCallToAction ()Ljava/lang/String;
+	public final fun getHeadline ()Ljava/lang/String;
+	public final fun getIcon ()Lapp/lexilabs/basic/ads/nativead/NativeAdData$Image;
+	public final fun getMediaContent ()Lapp/lexilabs/basic/ads/nativead/NativeAdData$MediaContent;
+	public final fun getMuteThisAdReasons ()Ljava/util/List;
+	public final fun getPlacementId ()Ljava/lang/Long;
+	public final fun getPrice ()Ljava/lang/String;
+	public final fun getStarRating ()Ljava/lang/Double;
+	public final fun getStore ()Ljava/lang/String;
+}
+
+public final class app/lexilabs/basic/ads/nativead/NativeAdData$AdChoicesInfo {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;Ljava/lang/CharSequence;)V
+	public final fun getImages ()Ljava/util/List;
+	public final fun getText ()Ljava/lang/CharSequence;
+}
+
+public final class app/lexilabs/basic/ads/nativead/NativeAdData$Image {
+	public static final field $stable I
+	public fun <init> (Landroid/graphics/drawable/Drawable;DLandroid/net/Uri;)V
+	public final fun getDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getScale ()D
+	public final fun getUri ()Landroid/net/Uri;
+}
+
+public final class app/lexilabs/basic/ads/nativead/NativeAdData$MediaContent {
+	public static final field $stable I
+	public fun <init> (FFFLandroid/graphics/drawable/Drawable;Lcom/google/android/gms/ads/VideoController;)V
+	public final fun getAspectRatio ()F
+	public final fun getCurrentTime ()F
+	public final fun getDuration ()F
+	public final fun getMainImage ()Landroid/graphics/drawable/Drawable;
+	public final fun getVideoController ()Lcom/google/android/gms/ads/VideoController;
+}
+
+public final class app/lexilabs/basic/ads/nativead/NativeAdData$MuteThisAdReason {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getDescription ()Ljava/lang/String;
+}
+
+public final class app/lexilabs/basic/ads/nativead/NativeAdHandler {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun destroy ()V
+	public final fun getNativeAd ()Lcom/google/android/gms/ads/nativead/NativeAd;
+	public final fun getState ()Lapp/lexilabs/basic/ads/AdState;
+	public final fun load (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun load$default (Lapp/lexilabs/basic/ads/nativead/NativeAdHandler;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun render ()Lapp/lexilabs/basic/ads/nativead/NativeAdData;
+	public final fun setNativeAd (Lcom/google/android/gms/ads/nativead/NativeAd;)V
 }
 

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdUnitId.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/AdUnitId.kt
@@ -8,4 +8,5 @@ public actual object AdUnitId {
     public actual const val INTERSTITIAL_DEFAULT: String = "ca-app-pub-3940256099942544/1033173712"
     public actual const val REWARDED_INTERSTITIAL_DEFAULT: String = "ca-app-pub-3940256099942544/5354046379"
     public actual const val REWARDED_DEFAULT: String = "ca-app-pub-3940256099942544/5224354917"
+    public actual const val NATIVE_DEFAULT: String = "ca-app-pub-3940256099942544/2247696110"
 }

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/composable/BannerAd.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/composable/BannerAd.kt
@@ -19,6 +19,12 @@ import app.lexilabs.basic.ads.toAndroid
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdView
 
+/**
+ * Loads and displays a Banner Ad using a [Composable].
+ * @param adUnitId Your AdMob AdUnitId [String]
+ * @param adSize The size of the banner ad
+ * @param onLoad Lambda expression that executes after the ad is loaded
+ */
 @OptIn(DependsOnGoogleMobileAds::class)
 @RequiresPermission("android.permission.INTERNET")
 @Composable

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/composable/NativeAdDefault.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/composable/NativeAdDefault.kt
@@ -1,0 +1,84 @@
+package app.lexilabs.basic.ads.composable
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+import app.lexilabs.basic.ads.nativead.NativeAdData
+
+/**
+ * A default implementation of a native ad.
+ * @param activity the current Activity (only needed for Android Impl)
+ * @param nativeAd the native ad to display
+ */
+@Composable
+public actual fun NativeAdDefault(activity: Any?, nativeAd: NativeAdData) {
+    /** Display a native ad with a user defined template. */
+    Box(modifier = Modifier.padding(8.dp).wrapContentHeight(Alignment.Top)) {
+        // Inside the NativeAdView composable, display the native ad assets.
+        Column(Modifier.align(Alignment.TopStart).wrapContentHeight(Alignment.Top)) {
+            // Display the ad attribution.
+            BasicText(text = "ad")
+            Row {
+                // If available, display the icon asset.
+                nativeAd.icon?.let { icon ->
+                    icon.drawable?.toBitmap()?.let { bitmap ->
+                        Image(bitmap = bitmap.asImageBitmap(), "Icon") }
+                }
+            }
+            Column {
+                // If available, display the headline asset.
+                nativeAd.headline?.let {
+                    BasicText(text = it)
+
+                }
+                // If available, display the star rating asset.
+                nativeAd.starRating?.let {
+                    BasicText(text = "Rated $it")
+                }
+            }
+
+            // If available, display the body asset.
+            nativeAd.body?.let { BasicText(text = it) }
+
+            Row(Modifier.align(Alignment.End).padding(5.dp)) {
+                // If available, display the price asset.
+                nativeAd.price?.let {
+                    BasicText(text = it)
+                }
+                // If available, display the store asset.
+                nativeAd.store?.let {
+                    BasicText(text = it)
+                }
+                // If available, display the call to action asset.
+                // Note: The Jetpack Compose button implements a click handler which overrides the native
+                // ad click handler, causing issues. Use the NativeAdButton which does not implement a
+                // click handler. To handle native ad clicks, use the NativeAd AdListener onAdClicked
+                // callback.
+                nativeAd.callToAction?.let { callToAction ->
+                    Box(
+                        Modifier
+                            .padding(5.dp)
+                            .clickable(
+                                onClick = {
+                                    // TODO: Fix onclick issue described above
+                                }
+                            )
+                    ) {
+                        BasicText(text = callToAction)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdConverters.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdConverters.kt
@@ -1,0 +1,53 @@
+package app.lexilabs.basic.ads.nativead
+
+import com.google.android.gms.ads.MediaContent
+import com.google.android.gms.ads.MuteThisAdReason
+import com.google.android.gms.ads.nativead.NativeAd
+
+public fun NativeAd.toCommon(): NativeAdData {
+    return NativeAdData(
+        adChoicesInfo = this.adChoicesInfo?.toCommon(),
+        advertiser = this.advertiser,
+        body = this.body,
+        callToAction = this.callToAction,
+        headline = this.headline,
+        icon = this.icon?.toCommon(),
+        mediaContent = this.mediaContent?.toCommon(),
+        muteThisAdReasons = this.muteThisAdReasons.map{ it.toCommon() },
+        placementId = this.placementId,
+        price = this.price,
+        starRating = this.starRating,
+        store = this.store
+    )
+}
+
+public fun NativeAd.AdChoicesInfo.toCommon(): NativeAdData.AdChoicesInfo {
+    return NativeAdData.AdChoicesInfo(
+        images = this.images.map { it.toCommon() },
+        text = this.text
+    )
+}
+
+public fun NativeAd.Image.toCommon(): NativeAdData.Image {
+    return NativeAdData.Image(
+        drawable = this.drawable,
+        scale = this.scale,
+        uri = this.uri
+    )
+}
+
+public fun MediaContent.toCommon(): NativeAdData.MediaContent {
+    return NativeAdData.MediaContent(
+        aspectRatio = this.aspectRatio,
+        currentTime = this.currentTime,
+        duration = this.duration,
+        mainImage = this.mainImage,
+        videoController = this.videoController,
+    )
+}
+
+public fun MuteThisAdReason.toCommon(): NativeAdData.MuteThisAdReason {
+    return NativeAdData.MuteThisAdReason(
+        description = this.description
+    )
+}

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdData.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdData.kt
@@ -1,0 +1,40 @@
+package app.lexilabs.basic.ads.nativead
+
+import android.graphics.drawable.Drawable
+import android.net.Uri
+import com.google.android.gms.ads.VideoController
+
+public actual class NativeAdData (
+    public actual val adChoicesInfo: AdChoicesInfo?,
+    public actual val advertiser: String?,
+    public actual val body: String?,
+    public actual val callToAction: String?,
+    public actual val headline: String?,
+    public actual val icon: Image?,
+    public actual val mediaContent: MediaContent?,
+    public actual val muteThisAdReasons: List<MuteThisAdReason>,
+    public actual val placementId: Long?,
+    public actual val price: String?,
+    public actual val starRating: Double?,
+    public actual val store: String?
+) {
+    public actual class AdChoicesInfo (
+        public val images: List<Image>,
+        public val text: CharSequence
+    )
+    public actual class Image (
+        public val drawable: Drawable?,
+        public val scale: Double,
+        public val uri: Uri?
+    )
+    public actual class MediaContent(
+        public val aspectRatio: Float,
+        public val currentTime: Float,
+        public val duration: Float,
+        public val mainImage: Drawable?,
+        public val videoController: VideoController,
+    )
+    public actual class MuteThisAdReason(
+        public val description: String
+    )
+}

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
@@ -1,0 +1,108 @@
+package app.lexilabs.basic.ads.nativead
+
+import android.app.Activity
+import androidx.annotation.MainThread
+import androidx.annotation.RequiresPermission
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import app.lexilabs.basic.ads.AdException
+import app.lexilabs.basic.ads.AdState
+import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
+import app.lexilabs.basic.logging.Log
+import com.google.android.gms.ads.AdListener
+import com.google.android.gms.ads.AdLoader
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.LoadAdError
+import com.google.android.gms.ads.nativead.NativeAd
+import com.google.android.gms.ads.nativead.NativeAdOptions
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+@DependsOnGoogleMobileAds
+public actual class NativeAdHandler actual constructor(private val activity: Any?) {
+
+    private val tag = "NativeAd"
+    public var nativeAd: NativeAd? = null
+    private val _state: MutableState<AdState> = mutableStateOf(AdState.NONE)
+
+    /**
+     * Determines the [AdState] of the [app.lexilabs.basic.ads.nativead.NativeAdHandler]
+     */
+    public actual val state: AdState by _state
+
+    @RequiresPermission(android.Manifest.permission.INTERNET)
+    public actual fun load(
+        adUnitId: String,
+        onLoad: () -> Unit,
+        onFailure: (Exception) -> Unit,
+        onDismissed: () -> Unit,
+        onShown: () -> Unit,
+        onImpression: () -> Unit,
+        onClick: () -> Unit
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            _state.value = AdState.LOADING
+            val adLoader = AdLoader.Builder(activity as Activity, adUnitId)
+                .forNativeAd {
+                    nativeAd = it
+                    _state.value = AdState.READY
+                    onLoad()
+                }
+                .withAdListener(
+                    object : AdListener() {
+                        override fun onAdFailedToLoad(adError: LoadAdError) {
+                            // The native ad load failed. Check the adError message for failure reasons.
+                            _state.value = AdState.FAILING
+                            Log.e(tag, "failure: ${adError.message}")
+                            onFailure(AdException(adError.message))
+                        }
+
+                        override fun onAdClicked() {
+                            super.onAdClicked()
+                            Log.i(tag, "Ad Clicked")
+                            onClick()
+                        }
+
+                        override fun onAdClosed() {
+                            super.onAdClosed()
+                            Log.i(tag, "Ad Dismissed")
+                            onDismissed()
+                        }
+
+                        override fun onAdImpression() {
+                            super.onAdImpression()
+                            Log.i(tag, "Ad made an impression")
+                            onImpression()
+                        }
+
+                        override fun onAdOpened() {
+                            super.onAdOpened()
+                            Log.i(tag, "Ad Opened")
+                            onShown()
+                        }
+                    }
+                )
+                // Use the NativeAdOptions.Builder class to specify individual options settings.
+                .withNativeAdOptions(NativeAdOptions.Builder().build())
+                .build()
+            adLoader.loadAd(AdRequest.Builder().build())
+        }
+    }
+
+    /**
+     * Shows the [app.lexilabs.basic.ads.nativead.NativeAdHandler].
+     */
+    @MainThread
+    public actual fun render(): NativeAdData {
+        require(nativeAd != null){
+            "NativeAd has not loaded"
+        }
+        return nativeAd!!.toCommon()
+    }
+
+    public actual fun destroy() {
+        nativeAd?.destroy()
+    }
+}

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdUnitId.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/AdUnitId.kt
@@ -27,4 +27,5 @@ public expect object AdUnitId {
     public val INTERSTITIAL_DEFAULT: String
     public val REWARDED_INTERSTITIAL_DEFAULT: String
     public val REWARDED_DEFAULT: String
+    public val NATIVE_DEFAULT: String
 }

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/NativeAd.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/NativeAd.kt
@@ -1,0 +1,60 @@
+package app.lexilabs.basic.ads.composable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import app.lexilabs.basic.ads.AdUnitId
+import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
+import app.lexilabs.basic.ads.nativead.NativeAdData
+import app.lexilabs.basic.ads.nativead.NativeAdHandler
+
+/**
+ * A composable that displays a native ad.
+ * @param activity the current Activity (only needed for Android Impl)
+ * @param nativeAdTemplate the composable that will be used to display the native ad
+ * @param adUnitId the ad unit ID for the native ad
+ * @param onDismissed a callback that will be invoked when the ad is dismissed
+ * @param onShown a callback that will be invoked when the ad is shown
+ * @param onImpression a callback that will be invoked when an impression is recorded for the ad
+ * @param onClick a callback that will be invoked when the ad is clicked
+ * @param onFailure a callback that will be invoked when the ad fails to load
+ * @param onLoad a callback that will be invoked when the ad has loaded
+ */
+@DependsOnGoogleMobileAds
+@Composable
+public fun NativeAd(
+    activity: Any?,
+    nativeAdTemplate: @Composable (NativeAdData) -> Unit,
+    adUnitId: String = AdUnitId.NATIVE_DEFAULT,
+    onDismissed: () -> Unit = {},
+    onShown: () -> Unit = {},
+    onImpression: () -> Unit = {},
+    onClick: () -> Unit = {},
+    onFailure: (Exception) -> Unit = {},
+    onLoad: () -> Unit = {}
+) {
+    val ad by rememberNativeAd(
+        activity = activity,
+        adUnitId = adUnitId,
+        onLoad = onLoad,
+        onFailure = onFailure,
+        onDismissed = onDismissed,
+        onShown = onShown,
+        onImpression = onImpression,
+        onClick = onClick
+    )
+    nativeAdTemplate(ad.render())
+}
+
+/**
+ * A composable that displays a native ad.
+ * @param loadedAd the pre-loaded native ad
+ * @param nativeAdTemplate the composable that will be used to display the native ad
+ */
+@DependsOnGoogleMobileAds
+@Composable
+public fun NativeAd(
+    loadedAd: NativeAdHandler,
+    nativeAdTemplate: @Composable (NativeAdData) -> Unit,
+) {
+    nativeAdTemplate(loadedAd.render())
+}

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/NativeAdDefault.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/NativeAdDefault.kt
@@ -1,0 +1,12 @@
+package app.lexilabs.basic.ads.composable
+
+import androidx.compose.runtime.Composable
+import app.lexilabs.basic.ads.nativead.NativeAdData
+
+/**
+ * A default implementation of a native ad.
+ * @param activity the current Activity (only needed for Android Impl)
+ * @param nativeAd the native ad to display
+ */
+@Composable
+public expect fun NativeAdDefault(activity: Any?, nativeAd: NativeAdData)

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberNativeAd.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/composable/RememberNativeAd.kt
@@ -1,0 +1,60 @@
+package app.lexilabs.basic.ads.composable
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import app.lexilabs.basic.ads.AdState
+import app.lexilabs.basic.ads.AdUnitId
+import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
+import app.lexilabs.basic.ads.nativead.NativeAdHandler
+
+/**
+ * Remembers a [NativeAdHandler] across compositions.
+ * @param activity the current Activity (only needed for Android Impl)
+ * @param adUnitId Your AdMob AdUnitId [String]
+ * @param onLoad Lambda expression that executes after the [NativeAdHandler] has fully loaded
+ * @param onFailure Lambda expression that executes after the ad fails to load or redirect
+ * @param onDismissed Lambda that executes when the user closes the ad
+ * @param onShown Lambda expression that executes after the ad is presented
+ * @param onImpression Lambda expression that executes after the user has seen the ad
+ * @param onClick Lambda expression that executes after the user clicks the ad
+ * @return a [MutableState] of [NativeAdHandler]
+ * @see AdUnitId.autoSelect
+ */
+@DependsOnGoogleMobileAds
+@Composable
+public fun rememberNativeAd(
+    activity: Any?,
+    adUnitId: String = AdUnitId.NATIVE_DEFAULT,
+    onLoad: () -> Unit = {},
+    onFailure: (Exception) -> Unit = {},
+    onDismissed: () -> Unit = {},
+    onShown: () -> Unit = {},
+    onImpression: () -> Unit = {},
+    onClick: () -> Unit = {},
+): MutableState<NativeAdHandler> {
+    val ad = remember(activity) { mutableStateOf(NativeAdHandler(activity)) }
+    DisposableEffect(ad) {
+        onDispose {
+            ad.value.destroy()
+        }
+    }
+    when(ad.value.state){
+        AdState.DISMISSED,
+        AdState.NONE -> {
+            ad.value.load(
+                adUnitId = adUnitId,
+                onLoad = onLoad,
+                onFailure = onFailure,
+                onDismissed = onDismissed,
+                onShown = onShown,
+                onImpression = onImpression,
+                onClick = onClick
+            )
+        }
+        else -> { /** DO NOTHING **/ }
+    }
+    return ad
+}

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdData.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdData.kt
@@ -1,0 +1,20 @@
+package app.lexilabs.basic.ads.nativead
+
+public expect class NativeAdData{
+    public val adChoicesInfo: AdChoicesInfo?
+    public val advertiser: String?
+    public val body: String?
+    public val callToAction: String?
+    public val headline: String?
+    public val icon: Image?
+    public val mediaContent: MediaContent?
+    public val muteThisAdReasons: List<MuteThisAdReason>
+    public val placementId: Long?
+    public val price: String?
+    public val starRating: Double?
+    public val store: String?
+    public class AdChoicesInfo
+    public class Image
+    public class MediaContent
+    public class MuteThisAdReason
+}

--- a/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
+++ b/basic-ads/src/commonMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
@@ -1,0 +1,33 @@
+package app.lexilabs.basic.ads.nativead
+
+import androidx.annotation.MainThread
+import app.lexilabs.basic.ads.AdState
+import app.lexilabs.basic.ads.AdUnitId
+import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
+
+@DependsOnGoogleMobileAds
+public expect class NativeAdHandler(activity: Any?) {
+
+    /**
+     * Determines the [app.lexilabs.basic.ads.AdState] of the [NativeAdHandler]
+     */
+    public val state: AdState
+
+    public fun load(
+        adUnitId: String = AdUnitId.NATIVE_DEFAULT,
+        onLoad: () -> Unit,
+        onFailure: (Exception) -> Unit,
+        onDismissed: () -> Unit = {},
+        onShown: () -> Unit = {},
+        onImpression: () -> Unit = {},
+        onClick: () -> Unit = {}
+    )
+
+    /**
+     * Shows the [NativeAdHandler].
+     */
+    @MainThread
+    public fun render(): NativeAdData
+
+    public fun destroy()
+}

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdUnitId.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/AdUnitId.kt
@@ -9,4 +9,5 @@ public actual object AdUnitId {
     public actual const val INTERSTITIAL_DEFAULT: String = "ca-app-pub-3940256099942544/4411468910"
     public actual const val REWARDED_INTERSTITIAL_DEFAULT: String = "ca-app-pub-3940256099942544/6978759866"
     public actual const val REWARDED_DEFAULT: String = "ca-app-pub-3940256099942544/1712485313"
+    public actual const val NATIVE_DEFAULT: String = "ca-app-pub-3940256099942544/3986624511"
 }

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/composable/NativeAdDefault.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/composable/NativeAdDefault.kt
@@ -1,0 +1,78 @@
+package app.lexilabs.basic.ads.composable
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.lexilabs.basic.ads.nativead.NativeAdData
+import platform.UIKit.UIImageView
+
+@Composable
+public actual fun NativeAdDefault(activity: Any?, nativeAd: NativeAdData) {
+    /** Display a native ad with a user defined template. */
+    Box(modifier = Modifier.padding(8.dp).wrapContentHeight(Alignment.Top)) {
+        // Inside the NativeAdView composable, display the native ad assets.
+        Column(Modifier.align(Alignment.TopStart).wrapContentHeight(Alignment.Top)) {
+            // Display the ad attribution.
+            BasicText(text = "ad")
+            Row {
+                // If available, display the icon asset.
+                nativeAd.icon?.let { icon ->
+                    icon.image?.let {
+                        UIImageView().image = it
+                    }
+                }
+            }
+            Column {
+                // If available, display the headline asset.
+                nativeAd.headline?.let {
+                    BasicText(text = it)
+
+                }
+                // If available, display the star rating asset.
+                nativeAd.starRating?.let {
+                    BasicText(text = "Rated $it")
+                }
+            }
+
+            // If available, display the body asset.
+            nativeAd.body?.let { BasicText(text = it) }
+
+            Row(Modifier.align(Alignment.End).padding(5.dp)) {
+                // If available, display the price asset.
+                nativeAd.price?.let {
+                    BasicText(text = it)
+                }
+                // If available, display the store asset.
+                nativeAd.store?.let {
+                    BasicText(text = it)
+                }
+                // If available, display the call to action asset.
+                // Note: The Jetpack Compose button implements a click handler which overrides the native
+                // ad click handler, causing issues. Use the NativeAdButton which does not implement a
+                // click handler. To handle native ad clicks, use the NativeAd AdListener onAdClicked
+                // callback.
+                nativeAd.callToAction?.let { callToAction ->
+                    Box(
+                        Modifier
+                            .padding(5.dp)
+                            .clickable(
+                                onClick = {
+                                    // TODO: Fix onclick issue described above
+                                }
+                            )
+                    ) {
+                        BasicText(text = callToAction)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/AdLoader.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/AdLoader.kt
@@ -1,0 +1,34 @@
+package app.lexilabs.basic.ads.nativead
+
+import app.lexilabs.basic.ads.AdException
+import app.lexilabs.basic.logging.Log
+import cocoapods.Google_Mobile_Ads_SDK.GADAdLoader
+import cocoapods.Google_Mobile_Ads_SDK.GADAdLoaderDelegateProtocol
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSError
+import platform.darwin.NSObject
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+public class AdLoader(
+    public val onFailure: (Exception) -> Unit = {},
+    public val onLoaded: () -> Unit = {}
+): NSObject(), GADAdLoaderDelegateProtocol {
+
+    private val tag = "AdLoaderDelegate"
+
+    override fun adLoader(
+        adLoader: GADAdLoader,
+        didFailToReceiveAdWithError: NSError
+    ) {
+        superclass
+        Log.i(tag, "failure: ${didFailToReceiveAdWithError.localizedDescription}")
+        onFailure(AdException(didFailToReceiveAdWithError.localizedDescription))
+    }
+
+    override fun adLoaderDidFinishLoading(adLoader: GADAdLoader) {
+        superclass
+        Log.i(tag, "Ad Loaded")
+        onLoaded()
+    }
+}

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdConverters.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdConverters.kt
@@ -1,0 +1,46 @@
+package app.lexilabs.basic.ads.nativead
+
+import cocoapods.Google_Mobile_Ads_SDK.GADMediaContent
+import cocoapods.Google_Mobile_Ads_SDK.GADNativeAd
+import cocoapods.Google_Mobile_Ads_SDK.GADNativeAdImage
+import cocoapods.Google_Mobile_Ads_SDK.mainImage
+import kotlinx.cinterop.ExperimentalForeignApi
+
+@OptIn(ExperimentalForeignApi::class)
+public fun GADNativeAd.toCommon(): NativeAdData {
+    return NativeAdData(
+        adChoicesInfo = null,
+        advertiser = this.advertiser,
+        body = this.body,
+        callToAction = this.callToAction,
+        headline = this.headline,
+        icon = this.icon?.toCommon(),
+        mediaContent = this.mediaContent.toCommon(),
+        // The weird cast below is probably the issue if you're troubleshooting on iOS
+        muteThisAdReasons = this.muteThisAdReasons?.map{ it as NativeAdData.MuteThisAdReason } ?: emptyList(),
+        placementId = null,
+        price = this.price,
+        starRating = this.starRating?.doubleValue,
+        store = this.store
+    )
+}
+
+@OptIn(ExperimentalForeignApi::class)
+public fun GADNativeAdImage.toCommon(): NativeAdData.Image {
+    return NativeAdData.Image(
+        image = this.image,
+        scale = this.scale,
+        imageUrl = this.imageURL
+    )
+}
+
+@OptIn(ExperimentalForeignApi::class)
+public fun GADMediaContent.toCommon(): NativeAdData.MediaContent {
+    return NativeAdData.MediaContent(
+        aspectRatio = this.aspectRatio,
+        currentTime = this.currentTime,
+        duration = this.duration,
+        mainImage = this.mainImage,
+        videoController = this.videoController
+    )
+}

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdData.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdData.kt
@@ -1,0 +1,43 @@
+package app.lexilabs.basic.ads.nativead
+
+import cocoapods.Google_Mobile_Ads_SDK.GADVideoController
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreGraphics.CGFloat
+import platform.Foundation.NSURL
+import platform.UIKit.UIImage
+
+public actual class NativeAdData (
+    public actual val adChoicesInfo: AdChoicesInfo?,
+    public actual val advertiser: String?,
+    public actual val body: String?,
+    public actual val callToAction: String?,
+    public actual val headline: String?,
+    public actual val icon: Image?,
+    public actual val mediaContent: MediaContent?,
+    public actual val muteThisAdReasons: List<MuteThisAdReason>,
+    public actual val placementId: Long?,
+    public actual val price: String?,
+    public actual val starRating: Double?,
+    public actual val store: String?
+) {
+    public actual class AdChoicesInfo (
+        public val images: List<Image>,
+        public val text: CharSequence
+    )
+    public actual class Image (
+        public val image: UIImage?,
+        public val scale: CGFloat,
+        public val imageUrl: NSURL?
+    )
+    public actual class MediaContent @OptIn(ExperimentalForeignApi::class) constructor(
+        public val aspectRatio: Double,
+        public val currentTime: Double,
+        public val duration: Double,
+        public val mainImage: UIImage?,
+        public val videoController: GADVideoController,
+    )
+    public actual class MuteThisAdReason(
+        public val description: String
+    )
+
+}

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdDelegate.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdDelegate.kt
@@ -1,0 +1,48 @@
+package app.lexilabs.basic.ads.nativead
+
+import app.lexilabs.basic.logging.Log
+import cocoapods.Google_Mobile_Ads_SDK.GADNativeAd
+import cocoapods.Google_Mobile_Ads_SDK.GADNativeAdDelegateProtocol
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.darwin.NSObject
+
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+public class NativeAdDelegate(
+    private val onImpression: () -> Unit,
+    private val onClick: () -> Unit,
+    private val onShown: () -> Unit,
+    private val onDismissed: () -> Unit
+): NSObject(), GADNativeAdDelegateProtocol {
+
+    private val tag = "NativeAdDelegate"
+
+    override fun nativeAdDidRecordImpression(nativeAd: GADNativeAd) {
+        superclass
+        Log.i(tag, "Ad made an impression")
+        onImpression()
+    }
+
+    override fun nativeAdDidRecordClick(nativeAd: GADNativeAd) {
+        superclass
+        Log.i(tag, "User clicked ad")
+        onClick()
+    }
+
+    override fun nativeAdWillPresentScreen(nativeAd: GADNativeAd) {
+        superclass
+        Log.i(tag, "Ad is being shown")
+        onShown()
+    }
+
+    override fun nativeAdWillDismissScreen(nativeAd: GADNativeAd) {
+        superclass
+        Log.i(tag, "Ad is being dismissed")
+    }
+
+    override fun nativeAdDidDismissScreen(nativeAd: GADNativeAd) {
+        superclass
+        Log.i(tag, "Ad was dismissed")
+        onDismissed()
+    }
+}

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
@@ -1,0 +1,77 @@
+package app.lexilabs.basic.ads.nativead
+
+import androidx.annotation.MainThread
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import app.lexilabs.basic.ads.AdState
+import app.lexilabs.basic.ads.DependsOnGoogleMobileAds
+import kotlinx.cinterop.ExperimentalForeignApi
+
+@DependsOnGoogleMobileAds
+public actual class NativeAdHandler actual constructor(activity: Any?) {
+
+    @OptIn(ExperimentalForeignApi::class)
+    private var adLoader: NativeAdLoader? = null
+    private val _state: MutableState<AdState> = mutableStateOf(AdState.NONE)
+
+    /**
+     * Determines the [AdState] of the [app.lexilabs.basic.ads.nativead.NativeAdHandler]
+     */
+    public actual val state: AdState by _state
+
+    @OptIn(ExperimentalForeignApi::class)
+    public actual fun load(
+        adUnitId: String,
+        onLoad: () -> Unit,
+        onFailure: (Exception) -> Unit,
+        onDismissed: () -> Unit,
+        onShown: () -> Unit,
+        onImpression: () -> Unit,
+        onClick: () -> Unit
+    ) {
+        adLoader = NativeAdLoader(
+            adUnitId = adUnitId,
+            onLoad =  {
+                _state.value = AdState.READY
+                onLoad()
+            },
+            onFailure = {
+                _state.value = AdState.FAILING
+                onFailure(it)
+            },
+            onDismissed = {
+                _state.value = AdState.DISMISSED
+                onDismissed()
+            },
+            onShown = {
+                _state.value = AdState.SHOWN
+                onShown()
+            },
+            onImpression = {
+                _state.value = AdState.SHOWING
+                onImpression()
+            },
+            onClick = {
+                onClick()
+            }
+        )
+    }
+
+    /**
+     * Shows the [app.lexilabs.basic.ads.nativead.NativeAdHandler].
+     */
+    @OptIn(ExperimentalForeignApi::class)
+    @MainThread
+    public actual fun render(): NativeAdData {
+        require(adLoader?.nativeAd != null) {
+            "NativeAd is null"
+        }
+        return adLoader!!.nativeAd!!.toCommon()
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    public actual fun destroy() {
+        adLoader?.nativeAd = null
+    }
+}

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdLoader.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdLoader.kt
@@ -1,0 +1,92 @@
+package app.lexilabs.basic.ads.nativead
+
+import app.lexilabs.basic.ads.AdException
+import app.lexilabs.basic.ads.getRootViewController
+import app.lexilabs.basic.logging.Log
+import cocoapods.Google_Mobile_Ads_SDK.GADAdLoader
+import cocoapods.Google_Mobile_Ads_SDK.GADAdLoaderAdTypeNative
+import cocoapods.Google_Mobile_Ads_SDK.GADNativeAd
+import cocoapods.Google_Mobile_Ads_SDK.GADNativeAdLoaderDelegateProtocol
+import cocoapods.Google_Mobile_Ads_SDK.GADRequest
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.Foundation.NSError
+import platform.darwin.NSObject
+import kotlin.coroutines.resume
+
+@OptIn(ExperimentalForeignApi::class)
+public class NativeAdLoader(
+    private val adUnitId: String,
+    public val onLoad: () -> Unit,
+    public val onFailure: (Exception) -> Unit,
+    public val onDismissed: () -> Unit,
+    public val onShown: () -> Unit,
+    public val onImpression: () -> Unit,
+    public val onClick: () -> Unit
+): NSObject(), GADNativeAdLoaderDelegateProtocol {
+    public var nativeAd: GADNativeAd? = null
+    private var adLoader: GADAdLoader? = null
+    private var continuation: ((Result<GADNativeAd>) -> Unit)? = null
+
+    private val tag: String = "NativeAdLoader"
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    public suspend fun loadAd(): Result<GADNativeAd> = suspendCancellableCoroutine { cont ->
+        // Store the continuation to be resumed later by the delegate
+        this.continuation = { result ->
+            if (cont.isActive) {
+                cont.resume(result)
+            }
+        }
+
+        // Get the root view controller to present the ad
+        val rootViewController = getRootViewController()
+        if (rootViewController == null) {
+            continuation?.invoke(Result.failure(Exception("Root viewcontroller not found.")))
+            return@suspendCancellableCoroutine
+        }
+
+        // Initialize and load the ad
+        adLoader = GADAdLoader(
+            adUnitID = adUnitId, // Test Ad Unit ID
+            rootViewController = rootViewController,
+            adTypes = listOf(GADAdLoaderAdTypeNative),
+            options = null
+        ).apply {
+            delegate = this@NativeAdLoader
+            loadRequest(GADRequest())
+        }
+
+        // Handle cancellation
+        cont.invokeOnCancellation {
+            adLoader?.delegate = null
+            adLoader = null
+            continuation = null
+        }
+    }
+
+    override fun adLoader(
+        adLoader: GADAdLoader,
+        didReceiveNativeAd: GADNativeAd
+    ) {
+        Log.i(tag, "Ad Loaded")
+        onLoad()
+        this.nativeAd = didReceiveNativeAd
+        this.nativeAd!!.delegate = NativeAdDelegate(
+            onImpression = onImpression,
+            onClick = onClick,
+            onShown = onShown,
+            onDismissed = onDismissed
+        )
+    }
+
+    override fun adLoader(
+        adLoader: GADAdLoader,
+        didFailToReceiveAdWithError: NSError
+    ) {
+        Log.e(tag, "failure: ${didFailToReceiveAdWithError.localizedDescription}")
+        onFailure(AdException(didFailToReceiveAdWithError.localizedDescription))
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # BUILD INFO
-ads = "1.0.0-beta03"
+ads = "1.0.0-beta04"
 build-sdk-compile = "36"
 build-sdk-min = "24"
 build-sdk-target = "36"
@@ -8,7 +8,7 @@ build-ios-target-deployment = "13.0"
 kotlin = "2.2.20"
 agp = "8.13.0"
 # COCOAPODS DEPENDENCIES
-cocoapods-admob = "12.4.0"
+cocoapods-admob = "12.12.0"
 cocoapods-ump = "3.0.0"
 # DEPENDENCIES
 bcv = "0.18.1"


### PR DESCRIPTION
* Add initial support for Native Ads

This commit introduces the initial structure for displaying native ads on both Android and iOS. It includes the necessary handlers, data classes, and composable functions, although the core ad loading and display logic is not yet implemented.

*   **New API Components:**
    *   **`NativeAdData`**: A new data class in `commonMain` to hold the assets of a native ad (e.g., headline, body, advertiser).
    *   **`NativeAdHandler`**: An `expect` class in `commonMain` with `actual` implementations for Android and iOS. This class will manage the lifecycle of a native ad. The current implementation is a skeleton with `TODO()` markers.
    *   **`NativeAd` Composable**: A new composable function in `commonMain` to display a native ad. It takes a `nativeAdTemplate` composable lambda to render the ad UI.
    *   **`rememberNativeAd` Composable**: A helper function to create and remember a `NativeAdHandler` instance within a composition.

*   **Ad Unit ID:**
    *   Added `NATIVE_DEFAULT` test ad unit IDs to `AdUnitId` for both Android and iOS platforms.



* Refactor Native Ad API and introduce `expect`/`actual` for `NativeAdData`

This commit refactors the Native Ad implementation by moving all related classes into a `nativead` subpackage. It also converts `NativeAdData` from a `data class` into an `expect` class with platform-specific `actual` implementations, providing a richer, type-safe representation of native ad assets.

*   **Package Refactoring:**
    *   All files related to Native Ads (`NativeAdHandler`, `NativeAdData`, `NativeAd.kt`, `RememberNativeAd.kt`) have been moved from `app.lexilabs.basic.ads` to a new `app.lexilabs.basic.ads.nativead` package.

*   **API Enhancement (`NativeAdData`):**
    *   `NativeAdData` in `commonMain` is now an `expect class` instead of a `data class`.
    *   It exposes a more comprehensive set of properties, including `adChoicesInfo`, `mediaContent`, and `muteThisAdReasons`.
    *   Introduced nested `expect` classes: `AdChoicesInfo`, `Image`, `MediaContent`, and `MuteThisAdReason` to provide a common abstraction over platform-specific types.

*   **Platform Implementations:**
    *   Added `actual` implementations for `NativeAdData` on both Android and iOS, wrapping the corresponding classes from the Google Mobile Ads SDK (e.g., `com.google.android.gms.ads.nativead.NativeAd` on Android, `GADNativeAd` on iOS).
    *   New `NativeAdConverters.kt` files have been added for both Android and iOS to handle the conversion from platform-specific ad objects to the common `NativeAdData` class.



* Refactor Native Ad API and implement Android loading

This commit refactors the Native Ad API to simplify its usage and implements the ad loading and event handling logic for the Android platform.

*   **API Refactoring (Common):**
    *   The `load` and `setListeners` functions in `NativeAdHandler` have been merged into a single `load` function. This function now accepts all necessary event callbacks (`onLoad`, `onFailure`, `onDismissed`, `onShown`, `onImpression`, `onClick`).
    *   The `show(nativeAdTemplate)` function has been replaced with `render(): NativeAdData`. The `NativeAd` composable now calls `render()` and passes the resulting `NativeAdData` to the template.
    *   A `destroy()` function has been added to the `NativeAdHandler` to clean up ad resources.

*   **Android Implementation:**
    *   Implemented the `load` function in `NativeAdHandler` for Android. It uses `AdLoader.Builder` to request a native ad.
    *   An `AdListener` is used to handle ad lifecycle events (failure, click, impression, shown, dismissed) and invoke the corresponding callbacks.
    *   The `render()` function is implemented to convert the loaded `com.google.android.gms.ads.nativead.NativeAd` into the common `NativeAdData` class.
    *   The `destroy()` function now calls `nativeAd.destroy()`.

*   **iOS Implementation (Partial):**
    *   Created `AdLoaderDelegate` and `NativeAdDelegate` to handle `GADAdLoaderDelegateProtocol` and `GADNativeAdDelegateProtocol` respectively.
    *   The `load` function in the iOS `NativeAdHandler` has been updated to use `GADAdLoader`, but the implementation is incomplete (`TODO`).

*   **Composable Updates:**
    *   The `rememberNativeAd` and `NativeAd` composables have been updated to reflect the new `load` and `render` API in `NativeAdHandler`.
    *   The `NativeAd` composable that accepts a pre-loaded `NativeAdHandler` has been simplified, removing redundant listener parameters.



* Implement Native Ad loading on iOS

This commit implements the logic for loading and handling native ads on the iOS platform. It introduces a new `NativeAdLoader` class to manage the ad lifecycle and integrates it with the existing `NativeAdHandler`.

*   **New `NativeAdLoader` Class (iOS):**
    *   A new `NativeAdLoader` class has been created to encapsulate the native ad loading process on iOS.
    *   It implements `GADNativeAdLoaderDelegateProtocol` to handle ad loading success and failure callbacks from the Google Mobile Ads SDK.
    *   It uses `suspendCancellableCoroutine` to provide a modern, coroutine-based `loadAd` function.
    *   It manages the `GADNativeAd` instance and its delegate to forward events like impressions, clicks, and dismissals.

*   **Refactor `NativeAdHandler` (iOS):**
    *   The `load` function in `NativeAdHandler` is now implemented to use the new `NativeAdLoader`.
    *   It passes callbacks (`onLoad`, `onFailure`, `onShown`, etc.) to the `NativeAdLoader`, which are used to update the `AdState` of the handler.
    *   The `render()` function is updated to retrieve the loaded ad data from the `NativeAdLoader`.
    *   The `destroy()` function is implemented to clear the ad reference.

*   **File/Class Renaming:**
    *   The placeholder `AdLoaderDelegate.kt` file and class were renamed and their logic has been superseded by the more complete `NativeAdLoader`.



* Add default native ad template and improve lifecycle

This commit introduces a default composable, `NativeAdDefault`, for rendering native ads and improves the lifecycle management of the `NativeAdHandler`.

*   **New `NativeAdDefault` Composable:**
    *   Added a new `expect` composable `NativeAdDefault` in `commonMain` to provide a default UI for displaying native ads.
    *   Provided `actual` implementations for both Android and iOS that render common native ad assets like the icon, headline, body, and call to action.

*   **Lifecycle Management:**
    *   In `rememberNativeAd`, a `DisposableEffect` has been added to ensure that `nativeAd.value.destroy()` is called when the composable leaves the composition. This prevents potential resource leaks by properly cleaning up the `NativeAdHandler`.

*   **Code Cleanup:**
    *   Removed `TODO` comments from the `NativeAd` composable, as the new `NativeAdDefault` serves as the intended default template.



* Updated API Dump.



* Improve KDoc for Ad Composables

This commit enhances the KDoc documentation for several public composable functions related to ads, improving clarity and developer guidance.

*   **Documentation Added/Improved:**
    *   **`BannerAd.kt`**: Added KDoc for the `BannerAd` composable that accepts an `adUnitId`.
    *   **`NativeAd.kt`**: Added KDoc for both overloads of the `NativeAd` composable.
    *   **`NativeAdDefault.kt`**: Added KDoc for the `expect` and `actual` declarations of the `NativeAdDefault` composable.
    *   **`RememberNativeAd.kt`**: Added comprehensive KDoc for the `rememberNativeAd` composable.



---------