### PR TITLE
Refactor(build): Migrate to Kotlin Multiplatform Android Library plugin

### DIFF
--- a/basic-ads/build.gradle.kts
+++ b/basic-ads/build.gradle.kts
@@ -1,9 +1,10 @@
+import com.android.build.api.dsl.androidLibrary
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     alias(libs.plugins.multiplatform)
-    alias(libs.plugins.android.library)
+    alias(libs.plugins.multiplatform.library)
     alias(libs.plugins.kotlinx.binary.compatibility.validator)
     alias(libs.plugins.dokka)
     alias(libs.plugins.native.cocoapods)
@@ -52,6 +53,7 @@ kotlin {
         }
         androidMain.dependencies {
             compileOnly(libs.google.play.services.ads)
+            compileOnly(libs.android.core)
             compileOnly(libs.android.ump)
             api(libs.android.ump)
         }
@@ -71,34 +73,15 @@ kotlin {
         freeCompilerArgs.add("-Xexpect-actual-classes")
     }
 
-    // Android JVM target target options
-    androidTarget {
-        publishLibraryVariants("release", "debug")
-        compilations.all{
-            compileTaskProvider.configure{
-                compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_17)
-                }
-            }
-        }
-    }
-}
-
-android {
-    namespace = "app.lexilabs.basic.ads"
-    compileSdk = libs.versions.build.sdk.compile.get().toInt()
-
-    defaultConfig {
+    @Suppress("UnstableApiUsage")
+    androidLibrary{
+        namespace = "app.lexilabs.basic.ads"
+        compileSdk = libs.versions.build.sdk.compile.get().toInt()
         minSdk = libs.versions.build.sdk.min.get().toInt()
-    }
-    testOptions {
-        targetSdk = libs.versions.build.sdk.target.get().toInt()
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    buildFeatures{
-        compose = true
+        withJava()
+
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     alias(libs.plugins.multiplatform).apply(false)
-    alias(libs.plugins.android.library).apply(false)
+    alias(libs.plugins.multiplatform.library).apply(false)
     alias(libs.plugins.kotlinx.serialization.plugin)
     alias(libs.plugins.native.cocoapods)
     alias(libs.plugins.dokka)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ bcv = "0.18.1"
 dokka = "2.1.0" #"2.0.0"
 compose = "1.9.3"
 google-play-services-ads = "24.9.0"
+android-core = "1.17.0"
 annotations = "1.9.1"
 kover = "0.9.4"
 logging = "0.2.6"
@@ -25,13 +26,14 @@ maven-publish = "0.35.0"
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
 dokka-base = { module = "org.jetbrains.dokka:dokka-base", version.ref = "dokka" }
 google-play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "google-play-services-ads"}
+android-core = { module = "androidx.core:core-ktx", version.ref = "android-core"}
 annotations = { module = "androidx.annotation:annotation", version.ref = "annotations"}
 lexilabs-basic-logging = { module = "app.lexilabs.basic:basic-logging", version.ref = "logging" }
 android-ump = { module = "com.google.android.ump:user-messaging-platform", version.ref = "android-ump"}
 
 [plugins]
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-android-library = { id = "com.android.library", version.ref = "agp" }
+multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp"}
 kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "bcv"}
 kotlinx-serialization-plugin = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
 native-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }


### PR DESCRIPTION
This commit migrates the `basic-ads` module from using the standalone `com.android.library` Gradle plugin to the modern `com.android.kotlin.multiplatform.library` plugin.

This change simplifies the build configuration by replacing the separate `android {}` and `kotlin.androidTarget {}` blocks with a single `androidLibrary {}` block.

*   **Plugin Migration:**
    *   Updated `build.gradle.kts` and `libs.versions.toml` to use the `com.android.kotlin.multiplatform.library` plugin alias.

*   **Build Script Refactoring:**
    *   Replaced the legacy `android {}` configuration in `basic-ads/build.gradle.kts` with the new `androidLibrary {}` block.
    *   Consolidated Android-specific settings like `namespace`, `compileSdk`, `minSdk`, and `jvmTarget` into the new block.

*   **Dependency Update:**
    *   Added a `compileOnly` dependency on `androidx.core:core-ktx`.