### PR TITLE
Build: Add dependency remediations for security vulnerabilities

### DIFF
--- a/basic-ads/build.gradle.kts
+++ b/basic-ads/build.gradle.kts
@@ -56,6 +56,21 @@ kotlin {
             compileOnly(libs.android.core)
             compileOnly(libs.android.ump)
             api(libs.android.ump)
+            /** REMEDIATION **/
+            // CVE-2021-0341
+            compileOnly(libs.remediate.okhttp)
+            // CVE-2024-29371
+            compileOnly(libs.remediate.bitbucket)
+            // CVE-2025-67735
+            compileOnly(libs.remediate.netty.codec.http)
+            // CVE-2025-55163
+            compileOnly(libs.remediate.netty.codec.http2)
+            // CVE-2024-7254
+            compileOnly(libs.remediate.google.protobuf.kotlin)
+            // CVE-2024-7254
+            compileOnly(libs.remediate.google.protobuf.java)
+            // CVE-2021-33813
+            compileOnly(libs.remediate.jdom)
         }
         iosMain.dependencies {}
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,14 @@ android-core = { module = "androidx.core:core-ktx", version.ref = "android-core"
 annotations = { module = "androidx.annotation:annotation", version.ref = "annotations"}
 lexilabs-basic-logging = { module = "app.lexilabs.basic:basic-logging", version.ref = "logging" }
 android-ump = { module = "com.google.android.ump:user-messaging-platform", version.ref = "android-ump"}
+# REMEDIATION
+remediate-okhttp = { module = "com.squareup.okhttp3:okhttp", version = { strictly = "5.3.2" } }
+remediate-bitbucket = { module = "org.bitbucket.b_c:jose4j", version = { strictly = "0.9.6" } }
+remediate-netty-codec-http = { module = "io.netty:netty-codec-http", version = { strictly = "4.2.9.Final" } }
+remediate-netty-codec-http2 = { module = "io.netty:netty-codec-http2", version = { strictly = "4.2.9.Final" } }
+remediate-google-protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version = { strictly = "4.33.3"}}
+remediate-google-protobuf-java = { module = "com.google.protobuf:protobuf-java", version = { strictly = "4.33.3"}}
+remediate-jdom = { module = "org.jdom:jdom2", version = { strictly = "2.0.6.1" } }
 
 [plugins]
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
This commit introduces `compileOnly` dependencies with strictly enforced versions to mitigate several security vulnerabilities found in transitive dependencies.

*   **Vulnerability Remediation:**
    *   **CVE-2021-0341:** Forced `com.squareup.okhttp3:okhttp` to version `5.3.2`.
    *   **CVE-2024-29371:** Forced `org.bitbucket.b_c:jose4j` to version `0.9.6`.
    *   **CVE-2025-67735:** Forced `io.netty:netty-codec-http` to version `4.2.9.Final`.
    *   **CVE-2025-55163:** Forced `io.netty:netty-codec-http2` to version `4.2.9.Final`.
    *   **CVE-2024-7254:** Forced `com.google.protobuf:protobuf-kotlin` and `com.google.protobuf:protobuf-java` to version `4.33.3`.
    *   **CVE-2021-33813:** Forced `org.jdom:jdom2` to version `2.0.6.1`.

These changes ensure that the project resolves these transitive dependencies to non-vulnerable versions during the build process.