### PR TITLE
Fix: Remediate security vulnerabilities in transitive dependencies

### DIFF
--- a/basic-ads/build.gradle.kts
+++ b/basic-ads/build.gradle.kts
@@ -12,6 +12,45 @@ plugins {
     alias(libs.plugins.kover)
 }
 
+/** REMEDIATION **/
+dependencies {
+    /** This patches all transitive dependencies that have vulnerabilities **/
+    constraints {
+        androidMainImplementation(libs.remediate.okhttp) {
+            version { strictly(libs.versions.remediate.okhttp.get()) }
+            because("CVE-2021-0341")
+        }
+        androidMainImplementation(libs.remediate.bitbucket) {
+            version { strictly(libs.versions.remediate.bitbucket.get())}
+            because("CVE-2024-29371")
+        }
+        androidMainImplementation(libs.remediate.netty.codec.http){
+            version { strictly(libs.versions.remediate.netty.get())}
+            because("CVE-2025-67735")
+        }
+        androidMainImplementation(libs.remediate.netty.codec.http2){
+            version { strictly(libs.versions.remediate.netty.get())}
+            because("CVE-2025-55163")
+        }
+        androidMainImplementation(libs.remediate.google.protobuf.kotlin){
+            version { strictly(libs.versions.remediate.google.protobuf.get())}
+            because("CVE-2024-7254")
+        }
+        androidMainImplementation(libs.remediate.google.protobuf.java){
+            version { strictly(libs.versions.remediate.google.protobuf.get())}
+            because("CVE-2024-7254")
+        }
+        androidMainImplementation(libs.remediate.jdom){
+            version { strictly(libs.versions.remediate.jdom.get())}
+            because("CVE-2021-33813")
+        }
+        androidMainImplementation(libs.remediate.apache.compress){
+            version { strictly(libs.versions.remediate.apache.compress.get())}
+            because("CVE-2024-26308")
+        }
+    }
+}
+
 kotlin {
 
     // FORCES CHECK OF PUBLIC API DECLARATIONS
@@ -56,21 +95,6 @@ kotlin {
             compileOnly(libs.android.core)
             compileOnly(libs.android.ump)
             api(libs.android.ump)
-            /** REMEDIATION **/
-            // CVE-2021-0341
-            compileOnly(libs.remediate.okhttp)
-            // CVE-2024-29371
-            compileOnly(libs.remediate.bitbucket)
-            // CVE-2025-67735
-            compileOnly(libs.remediate.netty.codec.http)
-            // CVE-2025-55163
-            compileOnly(libs.remediate.netty.codec.http2)
-            // CVE-2024-7254
-            compileOnly(libs.remediate.google.protobuf.kotlin)
-            // CVE-2024-7254
-            compileOnly(libs.remediate.google.protobuf.java)
-            // CVE-2021-33813
-            compileOnly(libs.remediate.jdom)
         }
         iosMain.dependencies {}
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,13 @@ kover = "0.9.4"
 logging = "0.2.6"
 android-ump = "4.0.0"
 maven-publish = "0.35.0"
+# REMEDIATION
+remediate-okhttp = "5.3.2"
+remediate-bitbucket = "0.9.6"
+remediate-netty = "4.2.9.Final"
+remediate-google-protobuf = "4.33.3"
+remediate-jdom = "2.0.6.1"
+remediate-apache-compress = "1.28.0"
 
 [libraries]
 compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose" }
@@ -31,13 +38,14 @@ annotations = { module = "androidx.annotation:annotation", version.ref = "annota
 lexilabs-basic-logging = { module = "app.lexilabs.basic:basic-logging", version.ref = "logging" }
 android-ump = { module = "com.google.android.ump:user-messaging-platform", version.ref = "android-ump"}
 # REMEDIATION
-remediate-okhttp = { module = "com.squareup.okhttp3:okhttp", version = { strictly = "5.3.2" } }
-remediate-bitbucket = { module = "org.bitbucket.b_c:jose4j", version = { strictly = "0.9.6" } }
-remediate-netty-codec-http = { module = "io.netty:netty-codec-http", version = { strictly = "4.2.9.Final" } }
-remediate-netty-codec-http2 = { module = "io.netty:netty-codec-http2", version = { strictly = "4.2.9.Final" } }
-remediate-google-protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version = { strictly = "4.33.3"}}
-remediate-google-protobuf-java = { module = "com.google.protobuf:protobuf-java", version = { strictly = "4.33.3"}}
-remediate-jdom = { module = "org.jdom:jdom2", version = { strictly = "2.0.6.1" } }
+remediate-okhttp = { module = "com.squareup.okhttp3:okhttp" }
+remediate-bitbucket = { module = "org.bitbucket.b_c:jose4j" }
+remediate-netty-codec-http = { module = "io.netty:netty-codec-http" }
+remediate-netty-codec-http2 = { module = "io.netty:netty-codec-http2" }
+remediate-google-protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin" }
+remediate-google-protobuf-java = { module = "com.google.protobuf:protobuf-java" }
+remediate-jdom = { module = "org.jdom:jdom2" }
+remediate-apache-compress = { module = "org.apache.commons:commons-compress" }
 
 [plugins]
 multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }


### PR DESCRIPTION
This commit updates the build configuration to mitigate several security vulnerabilities present in transitive dependencies. It replaces the previous `compileOnly` approach with Gradle's dependency constraints, which provides a more robust method for forcing specific, non-vulnerable versions of these libraries.

*   **Dependency Constraints:**
    *   A `constraints` block has been added to `basic-ads/build.gradle.kts` to enforce strict versions for vulnerable transitive dependencies on the `androidMain` configuration.

*   **Vulnerabilities Addressed:**
    *   **`okhttp`**: Patched for `CVE-2021-0341`.
    *   **`org.bitbucket.b_c:jose4j`**: Patched for `CVE-2024-29371`.
    *   **`io.netty`**: Patched for `CVE-2025-67735` and `CVE-2025-55163`.
    *   **`com.google.protobuf`**: Patched for `CVE-2024-7254`.
    *   **`org.jdom:jdom2`**: Patched for `CVE-2021-33813`.
    *   **`org.apache.commons:commons-compress`**: Added and patched for `CVE-2024-26308`.

*   **Build Configuration:**
    *   The `libs.versions.toml` file has been updated to centralize the version numbers for these remediated dependencies.