### PR TITLE
fix: correct misleading error message

### DIFF
--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/InterstitialAdHandler.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/InterstitialAdHandler.kt
@@ -94,7 +94,7 @@ public actual class InterstitialAdHandler actual constructor(
         Log.d(tag, "setListeners: Loading")
         require(interstitialAd != null) {
             _state.value = AdState.FAILING
-            "InterstitialAd not loaded yet. `InterstitialAd.load()` must be called first"
+            "The provided InterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., interstitialAdHandler.load()) before displaying the InterstitialAd composable."
         }
         interstitialAd?.let {
             interstitialAd?.fullScreenContentCallback = FullscreenContentDelegate(
@@ -133,7 +133,7 @@ public actual class InterstitialAdHandler actual constructor(
         }
         require(interstitialAd != null) {
             _state.value = AdState.FAILING
-            "InterstitialAd not loaded yet. `InterstitialAd.load()` must be called first"
+            "The provided InterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., interstitialAdHandler.load()) before displaying the InterstitialAd composable."
         }
         interstitialAd?.show(activity)
     }

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/RewardedAdHandler.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/RewardedAdHandler.kt
@@ -145,7 +145,7 @@ public actual class RewardedAdHandler actual constructor(private val activity: A
         Log.d(tag, "setListeners: Loading")
         require(rewardedAd != null) {
             _state.value = AdState.FAILING
-            "RewardedAd not loaded yet. `RewardedAd.load()` must be called first"
+            "The provided RewardedAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., rewardedAdHandler.load()) before displaying the RewardedAd composable."
         }
         rewardedAd?.let {
             rewardedAd?.fullScreenContentCallback = FullscreenContentDelegate(
@@ -187,7 +187,7 @@ public actual class RewardedAdHandler actual constructor(private val activity: A
         }
         require(rewardedAd != null) {
             _state.value = AdState.FAILING
-            "RewardedAd not loaded yet. `RewardedAd.load()` must be called first"
+            "The provided RewardedAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., rewardedAdHandler.load()) before displaying the RewardedAd composable."
         }
         rewardedAd?.show(activity) { reward ->
             Log.d(tag, "A reward was earned")

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/RewardedInterstitialAdHandler.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/RewardedInterstitialAdHandler.kt
@@ -89,7 +89,7 @@ public actual class RewardedInterstitialAdHandler actual constructor(
         Log.d(tag, "setListeners: Loading")
         require(rewardedInterstitialAd != null) {
             _state.value = AdState.FAILING
-            "RewardedAd not loaded yet. `RewardedAd.load()` must be called first"
+            "The provided RewardedInterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., rewardedInterstitialAdHandler.load()) before displaying the RewardedInterstitialAd composable."
         }
         rewardedInterstitialAd?.let {
             rewardedInterstitialAd?.fullScreenContentCallback = FullscreenContentDelegate(
@@ -129,7 +129,7 @@ public actual class RewardedInterstitialAdHandler actual constructor(
         }
         require(rewardedInterstitialAd != null) {
             _state.value = AdState.FAILING
-            "RewardedAd not loaded yet. `RewardedAd.load()` must be called first"
+            "The provided RewardedInterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., rewardedInterstitialAdHandler.load()) before displaying the RewardedInterstitialAd composable."
         }
         rewardedInterstitialAd?.show(activity) {
             Log.d(tag, "A reward was earned")

--- a/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
+++ b/basic-ads/src/androidMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
@@ -96,7 +96,7 @@ public actual class NativeAdHandler actual constructor(private val activity: Any
     @MainThread
     public actual fun render(): NativeAdData {
         require(ad?.android != null){
-            "NativeAd has not loaded"
+            "The provided NativeAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., nativeAdHandler.load()) before displaying the NativeAd composable."
         }
         return ad!!
     }

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/InterstitialAdHandler.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/InterstitialAdHandler.kt
@@ -60,7 +60,7 @@ public actual class InterstitialAdHandler actual constructor(activity: Any?) {
         Log.d(tag, "setListeners:starting")
         require(interstitialAd != null) {
             _state.value = AdState.FAILING
-            "InterstitialAd not loaded yet. `InterstitialAd.load()` must be called first"
+            "The provided InterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., interstitialAdHandler.load()) before displaying the InterstitialAd composable."
         }
         delegate = FullScreenContentDelegate(
             onClick = onClick,
@@ -87,11 +87,11 @@ public actual class InterstitialAdHandler actual constructor(activity: Any?) {
         Log.d(tag, "show:starting")
         require(interstitialAd != null) {
             _state.value = AdState.FAILING
-            "InterstitialAd not loaded yet. `InterstitialAd.load()` must be called first"
+            "The provided InterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., interstitialAdHandler.load()) before displaying the InterstitialAd composable."
         }
         require(delegate != null) {
             _state.value = AdState.FAILING
-            "InterstitialAd listeners not set yet. `InterstitialAd.setListeners()` must be called first"
+            "The provided InterstitialAdHandler listeners are not set yet. You must call .setListeners() on your handler instance (e.g., interstitialAdHandler.setListeners()) before displaying the InterstitialAd composable."
         }
         interstitialAd?.presentFromRootViewController(null)
     }
@@ -102,11 +102,11 @@ public actual class InterstitialAdHandler actual constructor(activity: Any?) {
         Log.d(tag, "show:starting")
         require(interstitialAd != null) {
             _state.value = AdState.FAILING
-            "InterstitialAd not loaded yet. `InterstitialAd.load()` must be called first"
+            "The provided InterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., interstitialAdHandler.load()) before displaying the InterstitialAd composable."
         }
         require(delegate != null) {
             _state.value = AdState.FAILING
-            "InterstitialAd listeners not set yet. `InterstitialAd.setListeners()` must be called first"
+            "The provided InterstitialAdHandler listeners are not set yet. You must call .setListeners() on your handler instance (e.g., interstitialAdHandler.setListeners()) before displaying the InterstitialAd composable."
         }
         interstitialAd?.presentFromRootViewController(viewController)
     }

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/RewardedAdHandler.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/RewardedAdHandler.kt
@@ -88,7 +88,7 @@ public actual class RewardedAdHandler actual constructor(activity: Any?) {
         Log.d(tag, "setListeners:starting")
         require(rewardedAd != null) {
             _state.value = AdState.FAILING
-            "RewardedAd not loaded yet. `RewardedAd.load()` must be called first"
+            "The provided RewardedAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., rewardedAdHandler.load()) before displaying the RewardedAd composable."
         }
         delegate = FullScreenContentDelegate(
             onClick = onClick,
@@ -116,11 +116,11 @@ public actual class RewardedAdHandler actual constructor(activity: Any?) {
         Log.d(tag, "show:starting")
         require(rewardedAd != null) {
             _state.value = AdState.FAILING
-            "RewardedAd not loaded yet. `RewardedAd.load()` must be called first"
+            "The provided RewardedAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., rewardedAdHandler.load()) before displaying the RewardedAd composable."
         }
         require(delegate != null) {
             _state.value = AdState.FAILING
-            "RewardedAd listeners not set yet. `RewardedAd.setListeners()` must be called first"
+            "The provided RewardedAdHandler listeners are not set yet. You must call .setListeners() on your handler instance (e.g., rewardedAdHandler.setListeners()) before displaying the RewardedAd composable."
         }
         rewardedAd?.let { ad ->
             ad.presentFromRootViewController(

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/RewardedInterstitialAdHandler.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/RewardedInterstitialAdHandler.kt
@@ -55,7 +55,7 @@ public actual class RewardedInterstitialAdHandler actual constructor(activity: A
         Log.d(tag, "setListeners:starting")
         require(rewardedInterstitialAd != null) {
             _state.value = AdState.FAILING
-            "RewardedAd not loaded yet. `RewardedAd.load()` must be called first"
+            "The provided RewardedInterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., rewardedInterstitialAdHandler.load()) before displaying the RewardedInterstitialAd composable."
         }
         delegate = FullScreenContentDelegate(
             onClick = onClick,
@@ -81,11 +81,11 @@ public actual class RewardedInterstitialAdHandler actual constructor(activity: A
         Log.d(tag, "show:starting")
         require(rewardedInterstitialAd != null) {
             _state.value = AdState.FAILING
-            "RewardedAd not loaded yet. `RewardedAd.load()` must be called first"
+            "The provided RewardedInterstitialAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., rewardedInterstitialAdHandler.load()) before displaying the RewardedInterstitialAd composable."
         }
         require(delegate != null) {
             _state.value = AdState.FAILING
-            "RewardedAd listeners not set yet. `RewardedAd.setListeners()` must be called first"
+            "The provided RewardedInterstitialAdHandler listeners are not set yet. You must call .setListeners() on your handler instance (e.g., rewardedInterstitialAdHandler.setListeners()) before displaying the RewardedInterstitialAd composable."
         }
         rewardedInterstitialAd?.presentFromRootViewController(
             viewController = null,

--- a/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
+++ b/basic-ads/src/iosMain/kotlin/app/lexilabs/basic/ads/nativead/NativeAdHandler.kt
@@ -74,7 +74,7 @@ public actual class NativeAdHandler actual constructor(activity: Any?) {
     @MainThread
     public actual fun render(): NativeAdData {
         require(adLoader?.nativeAd != null) {
-            "NativeAd is null"
+            "The provided NativeAdHandler is not loaded yet. You must call .load() on your handler instance (e.g., nativeAdHandler.load()) before displaying the NativeAd composable."
         }
         return NativeAdData(adLoader!!.nativeAd!!)
     }


### PR DESCRIPTION
## Overview
This PR improves the clarity of error messages across the library's ad handlers. The goal is to provide developers with precise, actionable guidance when they encounter runtime exceptions related to uninitialized or unloaded ad states.

## Context
As identified in our contribution plan, current error messages occasionally blend the names of the **UI Composables** (e.g., `RewardedAd`) with their corresponding **Logic Handlers** (e.g., `RewardedAdHandler`). Since the `load()` and `setListeners()` methods reside on handler instances rather than the Composable functions, this update ensures developers are directed to the correct object for resolution.

## Key Changes
- **Actionable Guidance**: Updated error strings to explicitly mention the handler instance and provide clear usage examples (e.g., `rewardedAdHandler.load()`).
- **Improved Accuracy**: Corrected naming inconsistencies in `RewardedInterstitialAdHandler` where error messages previously referred to it as a generic `RewardedAd`.
- **Platform Consistency**: Standardized these improvements across both Android and iOS source sets for a unified KMP developer experience.

## Affected Components
- **Handlers**: `RewardedInterstitialAdHandler`, `InterstitialAdHandler`, `RewardedAdHandler`, `NativeAdHandler`
- **Platforms**: Android and iOS

## Impact
These changes eliminate ambiguity during the debugging process, allowing developers to quickly resolve state-related issues by following the intuitive instructions provided directly within the exception messages.
